### PR TITLE
[FIX] Change Lerna publish jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,19 +5,29 @@
 
 version: 2.1
 orbs:
-  publish: 'hutson/library-release-workflows@4.3.3'
+  release-workflows: 'hutson/library-release-workflows@4.3.3'
 workflows:
   version: 2
   test-publish:
     jobs:
       - test
+      - release-workflows/lerna-deliver:
+          context: semantic_release
+          email: bot@algoan.com
+          filters:
+            branches:
+              only: master
+          fingerprint: '1a:a9:39:20:ed:37:35:23:82:d7:d8:62:2e:53:d3:8a'
+          fullname: Algoan bot
+          requires:
+            - test
       - release-workflows/lerna-deploy:
           context: semantic_release
           filters:
             branches:
               only: master
           requires:
-            - test
+            - release-workflows/lerna-deliver
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,19 +2,22 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+
+version: 2.1
+orbs:
+  publish: 'hutson/library-release-workflows@4.3.3'
 workflows:
   version: 2
   test-publish:
     jobs:
       - test
-      - publish:
+      - release-workflows/lerna-deploy:
           context: semantic_release
-          requires:
-            - test
           filters:
             branches:
               only: master
+          requires:
+            - test
 
 
 
@@ -52,12 +55,3 @@ jobs:
       - persist_to_workspace:
           root: ~/tmp
           paths: .
-  publish:
-    <<: *defaults
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ~/tmp
-      - run:
-          name: Publish changed packages to npm
-          command: npm run publish

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
+<p align="center">
+  <a href="http://nestjs.com"><img src="https://nestjs.com/img/logo_text.svg" alt="Nest Logo" width="320" /></a>
+</p>
+
+
 # Algoan NestJS components
+
+A collection of [NestJS](https://docs.nestjs.com) components.
+
+## NestJS Pagination
+
+A simple interceptor formatting a HTTP response with a `Link` header and a `Content-Range`.
+
+See [the documentation here](./packages/nestjs-pagination/README.md).

--- a/packages/nestjs-pagination/package-lock.json
+++ b/packages/nestjs-pagination/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@algoan/nestjs-pagination",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/nestjs-pagination/package.json
+++ b/packages/nestjs-pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algoan/nestjs-pagination",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "NestJS interceptor handling request's pagination",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
### Description

- Fix the @algoan/nestjs-pagination package version which was wrong
- Add [lerna-deploy](https://circleci.com/orbs/registry/orb/hutson/library-release-workflows#jobs-lerna-deploy) orbs in order to publish to NPM.