### PR TITLE
feat(nestjs-logging-interceptor): userPrefix in context,clearer messages

### DIFF
--- a/packages/nestjs-logging-interceptor/README.md
+++ b/packages/nestjs-logging-interceptor/README.md
@@ -17,6 +17,7 @@ npm install --save @algoan/nestjs-logging-interceptor
 ```
 
 ## Usage
+### Default usage
 Use the interceptor as a global interceptor (cf. refer to the [last paragraph](https://docs.nestjs.com/interceptors#binding-interceptors) of this section for more details).
 
 Example:
@@ -42,6 +43,42 @@ export class CoreModule {}
 
 In the example above, the interceptor is provided by the CoreModule. It could be set on any module that your main module is using.
 
+### Factory
+You can also manually pass an interceptor instance through a factory function. This will give the possibility to set a `userPrefix` on the head of the default context message:
+
+Example:
+
+```typescript
+import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { LoggingInterceptor } from '@algoan/nestjs-logging-interceptor';
+
+/**
+ * Core module: This module sets the logging interceptor as a global interceptor
+ */
+@Module({
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: () => {
+        const interceptor: LoggingInterceptor = new LoggingInterceptor();
+        interceptor.setUserPrefix('ExampleApp');
+
+        return interceptor;
+      },
+    },
+  ],
+})
+export class CoreModule {}
+```
+
+The context message will be preprend by the provided `userPrefix`:
+```bash
+[LoggingInterceptor - GET - /error] Incoming request - GET - /error
+==>
+[ExampleApp - LoggingInterceptor - GET - /error] Incoming request - GET - /error
+```
+
 ## Log messages
 
 This interceptor logs:
@@ -52,9 +89,9 @@ This interceptor logs:
 # Incoming request details
 
 # info level
-[Nest] 41835   - 04/02/2020, 5:02:10 PM   [LoggingInterceptor] LoggingInterceptor - GET - /
+[Nest] 27080   - 04/06/2020, 10:11:54 AM   [LoggingInterceptor - GET - /] Incoming request - GET - /
 # debug level
-[Nest] 41835   - 04/02/2020, 5:02:10 PM   [LoggingInterceptor - GET - /] Object:
+[Nest] 27080   - 04/06/2020, 10:11:54 AM   [LoggingInterceptor - GET - /] Object:
 {
   "message": "LoggingInterceptor - GET - /",
   "method": "GET",
@@ -73,9 +110,9 @@ This interceptor logs:
 # Success example
 
 # info level
-[Nest] 41835   - 04/02/2020, 5:02:10 PM   [LoggingInterceptor] LoggingInterceptor - 200 - GET - /
+[Nest] 27080   - 04/06/2020, 10:11:54 AM   [LoggingInterceptor - 200 - GET - /] Outgoing response - 200 - GET - /
 # debug level
-[Nest] 41835   - 04/02/2020, 5:02:10 PM   [LoggingInterceptor - 200 - GET - /] Object:
+[Nest] 27080   - 04/06/2020, 10:11:54 AM   [LoggingInterceptor - 200 - GET - /] Object:
 {
   "message": "LoggingInterceptor - 200 - GET - /",
   "body": "Hello World!"
@@ -84,7 +121,7 @@ This interceptor logs:
 # Warning example
 
 # warn level
-[Nest] 41835   - 04/02/2020, 5:07:44 PM   [LoggingInterceptor - 400 - GET - /badrequest] Object:
+[Nest] 27080   - 04/06/2020, 10:12:44 AM   [LoggingInterceptor - 400 - GET - /badrequest] Object:
 {
   "method": "GET",
   "url": "/badrequest",
@@ -103,7 +140,7 @@ This interceptor logs:
 # Error example
 
 # error level
-[Nest] 41835   - 04/02/2020, 5:10:10 PM   [LoggingInterceptor - 500 - GET - /error] Object:
+[Nest] 27080   - 04/06/2020, 10:12:17 AM   [LoggingInterceptor - 500 - GET - /error] Object:
 {
   "method": "GET",
   "url": "/error",

--- a/packages/nestjs-logging-interceptor/jest.config.js
+++ b/packages/nestjs-logging-interceptor/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
 
   // The directory where Jest should output its coverage files
   coverageDirectory: "coverage",
-  collectCoverageFrom: ["**/*.ts", "!test/**/*"],
+  collectCoverageFrom: ["**/*.ts", "!test/**/*", "!dist/**/*"],
 
   testEnvironment: "node",
 

--- a/packages/nestjs-logging-interceptor/test/logging.interceptor.test.ts
+++ b/packages/nestjs-logging-interceptor/test/logging.interceptor.test.ts
@@ -14,8 +14,8 @@ describe('Logging interceptor', () => {
 
     app = moduleRef.createNestApplication();
     app.useLogger(Logger);
-    // logger = moduleRef.get<Logger>(Logger);
 
+    
     await app.init();
   });
 
@@ -30,17 +30,21 @@ describe('Logging interceptor', () => {
   it('logs the input and output request details - OK status code', async () => {
     const logSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'log');
     const debugSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'debug');
+    const url: string = `/cats/ok`;
 
-    await request(app.getHttpServer()).get('/cats/ok').expect(HttpStatus.OK);
+    await request(app.getHttpServer()).get(url).expect(HttpStatus.OK);
 
-    const ctx: string = `LoggingInterceptor - GET - /cats/ok`;
-    const resCtx: string = `LoggingInterceptor - 200 - GET - /cats/ok`;
+    const ctx: string = `LoggingInterceptor - GET - ${url}`;
+    const resCtx: string = `LoggingInterceptor - 200 - GET - ${url}`;
+    const incomingMsg: string = `Incoming request - GET - ${url}`;
+    const outgoingMsg: string = `Outgoing response - 200 - GET - ${url}`;
+
     /**
      * log level
      */
     expect(logSpy).toBeCalledTimes(2);
-    expect(logSpy.mock.calls[0]).toEqual([ctx]);
-    expect(logSpy.mock.calls[1]).toEqual([resCtx]);
+    expect(logSpy.mock.calls[0]).toEqual([incomingMsg, ctx]);
+    expect(logSpy.mock.calls[1]).toEqual([outgoingMsg, resCtx]);
 
     /**
      * debug level
@@ -50,14 +54,14 @@ describe('Logging interceptor', () => {
       {
         body: {},
         headers: expect.any(Object),
-        message: ctx,
+        message: incomingMsg,
         method: `GET`,
       },
       ctx,
     ]);
     expect(debugSpy.mock.calls[1]).toEqual([
       {
-        message: resCtx,
+        message: outgoingMsg,
         body: `This action returns all cats`,
       },
       resCtx,
@@ -69,17 +73,20 @@ describe('Logging interceptor', () => {
     const debugSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'debug');
     const warnSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'warn');
     const errorSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'error');
+    const url: string = `/cats/badrequest`;
 
-    await request(app.getHttpServer()).get('/cats/badrequest').expect(HttpStatus.BAD_REQUEST);
-    // console.log(result.body)
-
-    const ctx: string = `LoggingInterceptor - GET - /cats/badrequest`;
-    const resCtx: string = `LoggingInterceptor - 400 - GET - /cats/badrequest`;
+    await request(app.getHttpServer()).get(url).expect(HttpStatus.BAD_REQUEST);
+    
+    
+    const ctx: string = `LoggingInterceptor - GET - ${url}`;
+    const resCtx: string = `LoggingInterceptor - 400 - GET - ${url}`;
+    const incomingMsg: string = `Incoming request - GET - ${url}`;
+    const outgoingMsg: string = `Outgoing response - 400 - GET - ${url}`;
     /**
      * log level
      */
     expect(logSpy).toBeCalledTimes(1);
-    expect(logSpy.mock.calls[0]).toEqual([ctx]);
+    expect(logSpy.mock.calls[0]).toEqual([incomingMsg, ctx]);
 
     /**
      * debug level
@@ -89,7 +96,7 @@ describe('Logging interceptor', () => {
       {
         body: {},
         headers: expect.any(Object),
-        message: ctx,
+        message: incomingMsg,
         method: `GET`,
       },
       ctx,
@@ -98,7 +105,7 @@ describe('Logging interceptor', () => {
     expect(warnSpy).toBeCalledTimes(1);
     expect(warnSpy.mock.calls[0]).toEqual([
       {
-        message: resCtx,
+        message: outgoingMsg,
         method: 'GET',
         url: '/cats/badrequest',
         body: {},
@@ -115,17 +122,20 @@ describe('Logging interceptor', () => {
     const debugSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'debug');
     const warnSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'warn');
     const errorSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'error');
+    const url: string = '/cats/internalerror';
 
-    await request(app.getHttpServer()).get('/cats/internalerror').expect(HttpStatus.INTERNAL_SERVER_ERROR);
+    await request(app.getHttpServer()).get(url).expect(HttpStatus.INTERNAL_SERVER_ERROR);
     // console.log(result.body)
 
-    const ctx: string = `LoggingInterceptor - GET - /cats/internalerror`;
-    const resCtx: string = `LoggingInterceptor - 500 - GET - /cats/internalerror`;
+    const ctx: string = `LoggingInterceptor - GET - ${url}`;
+    const resCtx: string = `LoggingInterceptor - 500 - GET - ${url}`;
+    const incomingMsg: string = `Incoming request - GET - ${url}`;
+    const outgoingMsg: string = `Outgoing response - 500 - GET - ${url}`;
     /**
      * log level
      */
     expect(logSpy).toBeCalledTimes(1);
-    expect(logSpy.mock.calls[0]).toEqual([ctx]);
+    expect(logSpy.mock.calls[0]).toEqual([incomingMsg, ctx]);
 
     /**
      * debug level
@@ -135,7 +145,7 @@ describe('Logging interceptor', () => {
       {
         body: {},
         headers: expect.any(Object),
-        message: ctx,
+        message: incomingMsg,
         method: `GET`,
       },
       ctx,
@@ -144,7 +154,7 @@ describe('Logging interceptor', () => {
     expect(errorSpy).toBeCalledTimes(1);
     expect(errorSpy.mock.calls[0]).toEqual([
       {
-        message: resCtx,
+        message: outgoingMsg,
         method: 'GET',
         url: '/cats/internalerror',
         body: {},


### PR DESCRIPTION
## Description

Possibility to provide the interceptor instances via an instance to set a userPrefix.

### Features

Possibility to add a userPrefix to the context message.
Readme updated.

Example:
```bash
[LoggingInterceptor - GET - /error] Incoming request - GET - /error
==>
[ExampleApp - LoggingInterceptor - GET - /error] Incoming request - GET - /error
```

### Improvements

Clearer context messages.