### PR TITLE
fix(nestjs-pagination): fetch correctly the limit and the page

### DIFF
--- a/packages/nestjs-pagination/src/mongo-pagination-param.decorator.ts
+++ b/packages/nestjs-pagination/src/mongo-pagination-param.decorator.ts
@@ -20,8 +20,8 @@ export const MongoPaginationParamDecorator: () => ParameterDecorator = createPar
     { pageName = 'page', perPageName = 'per_page' }: { pageName?: string; perPageName?: string } = {},
     req: Request,
   ): MongoPagination => {
-    const page: number = Number(req.query[pageName]) || FIRST_PAGE;
-    const limit: number = Number(req.query[perPageName]) || DEFAULT_NUMBER_OF_RESULTS;
+    const page: number = !isNaN(Number(req.query[pageName])) ? Number(req.query[pageName]) : FIRST_PAGE;
+    const limit: number = !isNaN(Number(req.query[perPageName])) ? Number(req.query[perPageName]) : DEFAULT_NUMBER_OF_RESULTS;
     let filter: {};
     let sort: [];
 

--- a/packages/nestjs-pagination/test/mongo-pagination-param.test.ts
+++ b/packages/nestjs-pagination/test/mongo-pagination-param.test.ts
@@ -70,4 +70,17 @@ describe('Tests related to the MongoPagination ParamDecorator', () => {
       sort: [],
     });
   });
+
+  it('MPPD06 - should successfully parse filters (per_page: 0)', () => {
+    const req: {} = { query: { page: '1', per_page: '0', filter: '{"key": "value"}', sort: '[]' } };
+
+    const result: MongoPagination = factory({}, req as Request);
+
+    expect(result).to.deep.equal({
+      filter: { key: 'value' },
+      limit: 0,
+      skip: 0,
+      sort: [],
+    });
+  });
 });


### PR DESCRIPTION
# fix(nestjs-pagination): fetch correctly the limit and the page
- Check if the limit is a number and set it if so (even if it is a `0` )
- Check if the page is a number and set it if so  (even if it is a `0` )