### PR TITLE
feat(nestjs-pagination): migrate the custom decorator to nest 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dist
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+.history

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -71,5 +71,10 @@
   "dependencies": {
     "content-range": "^1.1.0",
     "format-link-header": "^3.0.0"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "7.x.x",
+    "@nestjs/core": "7.x.x",
+    "@nestjs/platform-express": "7.x.x"
   }
 }

--- a/packages/pagination/src/index.ts
+++ b/packages/pagination/src/index.ts
@@ -1,2 +1,2 @@
 export { LinkHeaderInterceptor, Response } from './add-link-header.interceptor';
-export { MongoPaginationParamDecorator, MongoPagination } from './mongo-pagination-param.decorator';
+export { MongoPaginationParamDecorator, MongoPagination, getMongoQuery } from './mongo-pagination-param.decorator';

--- a/packages/pagination/src/mongo-pagination-param.decorator.ts
+++ b/packages/pagination/src/mongo-pagination-param.decorator.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, createParamDecorator } from '@nestjs/common';
+import { BadRequestException, createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { Request } from 'express';
 
 const FIRST_PAGE: number = 1;
@@ -18,8 +18,9 @@ export interface MongoPagination {
 export const MongoPaginationParamDecorator: () => ParameterDecorator = createParamDecorator(
   (
     { pageName = 'page', perPageName = 'per_page' }: { pageName?: string; perPageName?: string } = {},
-    req: Request,
+    ctx: ExecutionContext,
   ): MongoPagination => {
+    const req: Request = ctx.switchToHttp().getRequest();
     const page: number = !isNaN(Number(req.query[pageName])) ? Number(req.query[pageName]) : FIRST_PAGE;
     const limit: number = !isNaN(Number(req.query[perPageName]))
       ? Number(req.query[perPageName])

--- a/packages/pagination/test/add-link-header.test.ts
+++ b/packages/pagination/test/add-link-header.test.ts
@@ -13,6 +13,10 @@ describe('Tests related to the Link Header interceptor', () => {
     await app.init();
   });
 
+  after(async () => {
+    await app.close();
+  });
+
   describe('Tests with a limit of 100', () => {
     it('AD01 - should successfully add Link in headers without params', async () => {
       const res: request.Response = await request(app.getHttpServer()).get('/data').expect(200);

--- a/packages/pagination/test/helpers.ts
+++ b/packages/pagination/test/helpers.ts
@@ -3,7 +3,7 @@ import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
 import { CustomParamFactory } from '@nestjs/common/interfaces/features/custom-route-param-factory.interface';
 import { Test, TestingModule } from '@nestjs/testing';
 
-import { LinkHeaderInterceptor } from '../src';
+import { LinkHeaderInterceptor, MongoPagination, MongoPaginationParamDecorator } from '../src';
 
 /**
  * Fake data format
@@ -47,6 +47,14 @@ class FakeAppController {
   @Get('/data-custom-query')
   public async findAllWithCustomQuery(): Promise<{ totalDocs: number; resource: FakeDataToReturn[] }> {
     return this.findAll();
+  }
+
+  /**
+   * Test the pagination decorator
+   */
+  @Get('/pagination')
+  public async testPagination(@MongoPaginationParamDecorator() pagination: MongoPagination): Promise<{}> {
+    return { pagination };
   }
 }
 

--- a/packages/pagination/test/mongo-pagination-param.e2e.test.ts
+++ b/packages/pagination/test/mongo-pagination-param.e2e.test.ts
@@ -1,0 +1,41 @@
+import { INestApplication } from '@nestjs/common';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import { createTestAppModule } from './helpers';
+
+describe('E2e tests related to the MongoPagination ParamDecorator', () => {
+  let app: INestApplication;
+
+  before(async () => {
+    app = await createTestAppModule();
+    await app.init();
+  });
+
+  after(async () => {
+    await app.close();
+  });
+
+  describe('Tests with a pagination query', () => {
+    it('MPPDE01 - should successfully create the mongoQuery from the request', async () => {
+      const res: request.Response = await request(app.getHttpServer())
+        .get(
+          '/pagination?page=5&per_page=35&sort=%7B%22createdAt%22%3A-1%7D&filter=%7B%22status%22%3A%7B%22%24options%22%3A%22i%22%2C%22%24regex%22%3A%22ACCEPTED%22%7D%7D',
+        )
+        .expect(200);
+
+      expect(res.body.pagination).to.deep.equal({
+        filter: {
+          status: {
+            $options: 'i',
+            $regex: 'ACCEPTED',
+          },
+        },
+        limit: 35,
+        skip: 140,
+        sort: {
+          createdAt: -1,
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Rewrite the MongoPaginationParamDecorator so it can be used with nest 7

BREAKING CHANGE: The new decorator works with nest 7. This do not work with nest 6