### PR TITLE
[FIX] Change default log level

### DIFF
--- a/packages/logging-interceptor/README.md
+++ b/packages/logging-interceptor/README.md
@@ -89,8 +89,6 @@ This interceptor logs:
 # Incoming request details
 
 # info level
-[Nest] 27080   - 04/06/2020, 10:11:54 AM   [LoggingInterceptor - GET - /] Incoming request - GET - /
-# debug level
 [Nest] 27080   - 04/06/2020, 10:11:54 AM   [LoggingInterceptor - GET - /] Object:
 {
   "message": "LoggingInterceptor - GET - /",
@@ -104,14 +102,13 @@ This interceptor logs:
   }
 }
 ```
-  - outgoing request details (info + (debug | warn | error))
+
+- outgoing request details (info + (debug | warn | error))
 
 ```bash
 # Success example
 
-# info level
-[Nest] 27080   - 04/06/2020, 10:11:54 AM   [LoggingInterceptor - 200 - GET - /] Outgoing response - 200 - GET - /
-# debug level
+# Info level
 [Nest] 27080   - 04/06/2020, 10:11:54 AM   [LoggingInterceptor - 200 - GET - /] Object:
 {
   "message": "LoggingInterceptor - 200 - GET - /",
@@ -165,6 +162,7 @@ Error: Internal Server Error
 ### Use a custom Logger
 
 #### Nest-pino
+
 In this example, we are going to override the default Logger implementation with a Pino logger (refer to the [this official NestJS documentation](https://docs.nestjs.com/techniques/logger#using-the-logger-for-application-logging))
 
 ```typescript
@@ -182,7 +180,7 @@ import { LoggerModule } from 'nestjs-pino';
 export class AppModule {}
 ```
 
-Then in the application boostrap, set the Pino logger as the one to substitute to the default Logger.
+Then in the application bootstrap, set the [Pino logger](https://github.com/iamolegga/nestjs-pino) as the one to substitute to the default Logger.
 
 ```typescript
 import { NestFactory} from '@nestjs/core';

--- a/packages/logging-interceptor/src/logging.interceptor.ts
+++ b/packages/logging-interceptor/src/logging.interceptor.ts
@@ -39,8 +39,7 @@ export class LoggingInterceptor implements NestInterceptor {
     const ctx: string = `${this.userPrefix}${this.ctxPrefix} - ${method} - ${url}`;
     const message: string = `Incoming request - ${method} - ${url}`;
 
-    this.logger.log(message, ctx);
-    this.logger.debug(
+    this.logger.log(
       {
         message,
         method,
@@ -75,8 +74,7 @@ export class LoggingInterceptor implements NestInterceptor {
     const ctx: string = `${this.userPrefix}${this.ctxPrefix} - ${statusCode} - ${method} - ${url}`;
     const message: string = `Outgoing response - ${statusCode} - ${method} - ${url}`;
 
-    this.logger.log(message, ctx);
-    this.logger.debug(
+    this.logger.log(
       {
         message,
         body,

--- a/packages/logging-interceptor/test/logging.interceptor.test.ts
+++ b/packages/logging-interceptor/test/logging.interceptor.test.ts
@@ -28,7 +28,6 @@ describe('Logging interceptor', () => {
 
   it('logs the input and output request details - OK status code', async () => {
     const logSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'log');
-    const debugSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'debug');
     const url: string = `/cats/ok`;
 
     await request(app.getHttpServer()).get(url).expect(HttpStatus.OK);
@@ -39,17 +38,10 @@ describe('Logging interceptor', () => {
     const outgoingMsg: string = `Outgoing response - 200 - GET - ${url}`;
 
     /**
-     * log level
+     * Info level
      */
     expect(logSpy).toBeCalledTimes(2);
-    expect(logSpy.mock.calls[0]).toEqual([incomingMsg, ctx]);
-    expect(logSpy.mock.calls[1]).toEqual([outgoingMsg, resCtx]);
-
-    /**
-     * debug level
-     */
-    expect(debugSpy).toBeCalledTimes(2);
-    expect(debugSpy.mock.calls[0]).toEqual([
+    expect(logSpy.mock.calls[0]).toEqual([
       {
         body: {},
         headers: expect.any(Object),
@@ -58,7 +50,7 @@ describe('Logging interceptor', () => {
       },
       ctx,
     ]);
-    expect(debugSpy.mock.calls[1]).toEqual([
+    expect(logSpy.mock.calls[1]).toEqual([
       {
         message: outgoingMsg,
         body: `This action returns all cats`,
@@ -69,7 +61,6 @@ describe('Logging interceptor', () => {
 
   it('logs the input and output request details - BAD_REQUEST status code', async () => {
     const logSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'log');
-    const debugSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'debug');
     const warnSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'warn');
     const errorSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'error');
     const url: string = `/cats/badrequest`;
@@ -80,17 +71,12 @@ describe('Logging interceptor', () => {
     const resCtx: string = `LoggingInterceptor - 400 - GET - ${url}`;
     const incomingMsg: string = `Incoming request - GET - ${url}`;
     const outgoingMsg: string = `Outgoing response - 400 - GET - ${url}`;
-    /**
-     * log level
-     */
-    expect(logSpy).toBeCalledTimes(1);
-    expect(logSpy.mock.calls[0]).toEqual([incomingMsg, ctx]);
 
     /**
-     * debug level
+     * Info level
      */
-    expect(debugSpy).toBeCalledTimes(1);
-    expect(debugSpy.mock.calls[0]).toEqual([
+    expect(logSpy).toBeCalledTimes(1);
+    expect(logSpy.mock.calls[0]).toEqual([
       {
         body: {},
         headers: expect.any(Object),
@@ -117,29 +103,22 @@ describe('Logging interceptor', () => {
 
   it('logs the input and output request details - INTERNAL_SERVER_ERROR status code', async () => {
     const logSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'log');
-    const debugSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'debug');
     const warnSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'warn');
     const errorSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'error');
     const url: string = '/cats/internalerror';
 
     await request(app.getHttpServer()).get(url).expect(HttpStatus.INTERNAL_SERVER_ERROR);
-    // console.log(result.body)
 
     const ctx: string = `LoggingInterceptor - GET - ${url}`;
     const resCtx: string = `LoggingInterceptor - 500 - GET - ${url}`;
     const incomingMsg: string = `Incoming request - GET - ${url}`;
     const outgoingMsg: string = `Outgoing response - 500 - GET - ${url}`;
-    /**
-     * log level
-     */
-    expect(logSpy).toBeCalledTimes(1);
-    expect(logSpy.mock.calls[0]).toEqual([incomingMsg, ctx]);
 
     /**
-     * debug level
+     * Info level
      */
-    expect(debugSpy).toBeCalledTimes(1);
-    expect(debugSpy.mock.calls[0]).toEqual([
+    expect(logSpy).toBeCalledTimes(1);
+    expect(logSpy.mock.calls[0]).toEqual([
       {
         body: {},
         headers: expect.any(Object),


### PR DESCRIPTION
### Description

The defautk behavior has been changed in order to log requests and responses with the `log` level instead of the `debug` one.

- **TODO**: give to the user the ability to choose if he wants the `debug` level or not