### PR TITLE
fix(httpexceptionfilter): logging the trace instead of the error object

### DIFF
--- a/packages/http-exception-filter/README.md
+++ b/packages/http-exception-filter/README.md
@@ -98,14 +98,7 @@ bootstrap();
 [Nest] 96665   - 04/14/2020, 6:35:27 PM   [HttpExceptionFilter] Object:
 {
   "message": "400 [GET /badrequest] has thrown an HTTP client error",
-  "exception": {
-    "response": {
-      "statusCode": 400,
-      "message": "Bad Request"
-    },
-    "status": 400,
-    "message": "Bad Request"
-  },
+  "exceptionStack": "stackTrace",
   "headers": {
     "host": "localhost:3000",
     "user-agent": "insomnia/7.1.1",
@@ -122,14 +115,7 @@ bootstrap();
     "user-agent": "insomnia/7.1.1",
     "accept": "*/*"
   },
-  "exception": {
-    "response": {
-      "statusCode": 500,
-      "message": "Internal Server Error"
-    },
-    "status": 500,
-    "message": "Internal Server Error"
-  }
+  "exceptionStack": "stackTrace",
 }
 ```
  

--- a/packages/http-exception-filter/src/http-exception-filter.ts
+++ b/packages/http-exception-filter/src/http-exception-filter.ts
@@ -14,7 +14,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
   /**
    * Catch and format thrown exception
    */
-  public catch(exception: unknown, host: ArgumentsHost): void {
+  // tslint:disable-next-line: no-any
+  public catch(exception: any, host: ArgumentsHost): void {
     const ctx: HttpArgumentsHost = host.switchToHttp();
     const request: Request = ctx.getRequest();
     const response: Response = ctx.getResponse();
@@ -44,16 +45,17 @@ export class HttpExceptionFilter implements ExceptionFilter {
           - request size: ${get(exception, 'length')};
           - request limit: ${get(exception, 'limit')}.`;
     }
+    const exceptionStack: string = 'stack' in exception ? exception.stack : '';
     if (status >= HttpStatus.INTERNAL_SERVER_ERROR) {
       this.logger.error({
         message: `${status} [${request.method} ${request.url}] has thrown a critical error`,
         headers: request.headers,
-        exception,
+        exceptionStack,
       });
     } else if (status >= HttpStatus.BAD_REQUEST) {
       this.logger.warn({
         message: `${status} [${request.method} ${request.url}] has thrown an HTTP client error`,
-        exception,
+        exceptionStack,
         headers: request.headers,
       });
     }

--- a/packages/http-exception-filter/src/http-exception-filter.ts
+++ b/packages/http-exception-filter/src/http-exception-filter.ts
@@ -47,11 +47,13 @@ export class HttpExceptionFilter implements ExceptionFilter {
     }
     const exceptionStack: string = 'stack' in exception ? exception.stack : '';
     if (status >= HttpStatus.INTERNAL_SERVER_ERROR) {
-      this.logger.error({
-        message: `${status} [${request.method} ${request.url}] has thrown a critical error`,
-        headers: request.headers,
+      this.logger.error(
+        {
+          message: `${status} [${request.method} ${request.url}] has thrown a critical error`,
+          headers: request.headers,
+        },
         exceptionStack,
-      });
+      );
     } else if (status >= HttpStatus.BAD_REQUEST) {
       this.logger.warn({
         message: `${status} [${request.method} ${request.url}] has thrown an HTTP client error`,

--- a/packages/http-exception-filter/test/http-exception-filter.test.ts
+++ b/packages/http-exception-filter/test/http-exception-filter.test.ts
@@ -35,7 +35,7 @@ describe('Http Exception Filter', () => {
 
     expect(warnSpy).toHaveBeenCalledWith({
       message: `400 [GET ${url}] has thrown an HTTP client error`,
-      exception: expect.any(Error),
+      exceptionStack: expect.any(String),
       headers: expect.anything(),
     });
 
@@ -54,7 +54,7 @@ describe('Http Exception Filter', () => {
 
     expect(warnSpy).toHaveBeenCalledWith({
       message: `400 [POST ${url}] has thrown an HTTP client error`,
-      exception: expect.any(Error),
+      exceptionStack: expect.any(String),
       headers: expect.anything(),
     });
 
@@ -73,7 +73,7 @@ describe('Http Exception Filter', () => {
 
     expect(errorSpy).toHaveBeenCalledWith({
       message: `500 [GET ${url}] has thrown a critical error`,
-      exception: expect.any(Error),
+      exceptionStack: expect.any(String),
       headers: expect.anything(),
     });
 
@@ -100,7 +100,7 @@ describe('Http Exception Filter', () => {
 
     expect(warnSpy).toHaveBeenCalledWith({
       message: `413 [POST ${url}] has thrown an HTTP client error`,
-      exception: expect.any(Error),
+      exceptionStack: expect.any(String),
       headers: expect.anything(),
     });
 

--- a/packages/http-exception-filter/test/http-exception-filter.test.ts
+++ b/packages/http-exception-filter/test/http-exception-filter.test.ts
@@ -1,4 +1,4 @@
-import { INestApplication, Logger, HttpStatus, ValidationPipe } from '@nestjs/common';
+import { HttpStatus, INestApplication, Logger, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { CatsModule } from './test-app/cats/cats.module';
@@ -71,11 +71,13 @@ describe('Http Exception Filter', () => {
 
     const { body: resBody } = await request(app.getHttpServer()).get(url).expect(HttpStatus.INTERNAL_SERVER_ERROR);
 
-    expect(errorSpy).toHaveBeenCalledWith({
-      message: `500 [GET ${url}] has thrown a critical error`,
-      exceptionStack: expect.any(String),
-      headers: expect.anything(),
-    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      {
+        message: `500 [GET ${url}] has thrown a critical error`,
+        headers: expect.anything(),
+      },
+      expect.any(String),
+    );
 
     expect(resBody).toEqual({
       code: 'INTERNAL_SERVER_ERROR',


### PR DESCRIPTION
## Description

Since the exception received is a subclass of the Error class, we can log the exception.stack instead of the whole exception object.