### PR TITLE
[FIX] - Mongo Pagination - Change the filter interface

### DIFF
--- a/packages/pagination/src/mongo-pagination-param.decorator.ts
+++ b/packages/pagination/src/mongo-pagination-param.decorator.ts
@@ -8,7 +8,10 @@ const DEFAULT_NUMBER_OF_RESULTS: number = 10;
  * Mongo query
  */
 export interface MongoPagination {
-  filter: {};
+  filter: {
+    // tslint:disable-next-line: no-any
+    [key: string]: any;
+  };
   limit: number;
   skip: number;
   sort: [];


### PR DESCRIPTION
### Description

In order to use the `filter` property, we cannot use the `{}` type. Otherwise, TS is throwing a build error:

```ts
const foo: string | undefined = pagination.filter?.foo; // Property 'foo' does not exist on type '{}'.ts(2339)
```

- fix(mongo-pagination): update the filter type to be more generic