### PR TITLE
[FIX] Pagination interceptor - Content-Range header for empty values 

### DIFF
--- a/packages/pagination/src/add-link-header.interceptor.ts
+++ b/packages/pagination/src/add-link-header.interceptor.ts
@@ -175,6 +175,14 @@ export class LinkHeaderInterceptor<T> implements NestInterceptor<T, T[]> {
     let endIndex: number = Number(linkOptions.page) * limit;
     const startIndex: number = endIndex - limit;
 
+    /**
+     * If there is no document, return a "{resource} 0-0/0"
+     * NOTE: Otherwise the contentRange lib is returning "{resource} 0-NaN/0"
+     */
+    if (linkOptions.totalDocs === 0) {
+      return `${this.resource} 0-0/0`;
+    }
+
     if (endIndex > linkOptions.totalDocs) {
       endIndex = linkOptions.totalDocs + 1;
     }

--- a/packages/pagination/test/add-link-header.test.ts
+++ b/packages/pagination/test/add-link-header.test.ts
@@ -186,10 +186,35 @@ describe('Tests related to the Link Header interceptor', () => {
       expect(res.body.resource).to.be.undefined;
       expect(res.body).to.be.an('array');
     });
+
+    it('AD12 - should add link even if no document where found', async () => {
+      const res: request.Response = await request(app.getHttpServer()).get('/resources').expect(200);
+
+      const expectedResult: formatLinkHeader.Links = {
+        first: {
+          url: '/resources?page=1&per_page=100',
+          page: '1',
+          per_page: '100',
+          rel: 'first',
+        },
+        last: {
+          url: '/resources?page=1&per_page=100',
+          page: '1',
+          per_page: '100',
+          rel: 'last',
+        },
+      };
+
+      expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
+      expect(res.header['content-range']).to.equal('resources 0-0/0');
+      expect(res.body.totalDocs).to.be.undefined;
+      expect(res.body.resource).to.be.undefined;
+      expect(res.body).to.be.an('array');
+    });
   });
 
   describe('Tests with custom configuration', () => {
-    it('AD12 - should successfully handle custom query parameters', async () => {
+    it('AD20 - should successfully handle custom query parameters', async () => {
       const res: request.Response = await request(app.getHttpServer())
         .get('/data-custom-query?_page=41&numberPerPage=25')
         .expect(200);

--- a/packages/pagination/test/helpers.ts
+++ b/packages/pagination/test/helpers.ts
@@ -39,6 +39,15 @@ class FakeAppController {
   }
 
   /**
+   * Find no documents
+   */
+  @UseInterceptors(new LinkHeaderInterceptor({ resource: 'resources' }))
+  @Get('/resources')
+  public async find(): Promise<{ totalDocs: number; resource: FakeDataToReturn[] }> {
+    return { totalDocs: 0, resource: [] };
+  }
+
+  /**
    * Find all documents
    */
   @UseInterceptors(


### PR DESCRIPTION
### Description

- Return a correct result if there are no document returned by the API. Otherwise the content-range lib is returning a NaN value