### PR TITLE
fix: fixed update last rel calculation

### DIFF
--- a/packages/pagination/src/add-link-header.interceptor.ts
+++ b/packages/pagination/src/add-link-header.interceptor.ts
@@ -142,26 +142,24 @@ export class LinkHeaderInterceptor<T> implements NestInterceptor<T, T[]> {
     switch (rel) {
       case 'first':
         link.page = '1';
-        link.url += `?${this.pageName}=1`;
         break;
 
       case 'prev':
         link.page = (page - 1).toString();
-        link.url += `?${this.pageName}=${page - 1}`;
         break;
 
       case 'last':
-        link.url += `?${this.pageName}=${Math.floor(linkOptions.totalDocs / Number(linkOptions.limit)) + 1}`;
+        link.page = `${Math.ceil(linkOptions.totalDocs / Number(linkOptions.limit))}`;
+        link.page = link.page === '0' ? '1' : link.page;
         break;
 
       // Next relation
       default:
         link.page = (page + 1).toString();
-        link.url += `?${this.pageName}=${page + 1}`;
         break;
     }
 
-    link.url += `&${this.perPageName}=${linkOptions.limit}`;
+    link.url += `?${this.pageName}=${link.page}&${this.perPageName}=${linkOptions.limit}`;
 
     return link;
   };


### PR DESCRIPTION
## Description

This fix the calculation of `rel=last` page... In the previous behavior the last page was the same "filtered" page, also I change the Math.floor to Math.ceil to properly calculate the number of pages, in the old version, in some cases we can get one extra page, for example, with 20 items and 5 items per page, the old result was 5 pages, which is wrong, with the new behavior we get exactly 4 pages :D