### PR TITLE
feat: improved content range calculation

### DIFF
--- a/packages/pagination/src/add-link-header.interceptor.ts
+++ b/packages/pagination/src/add-link-header.interceptor.ts
@@ -106,7 +106,7 @@ export class LinkHeaderInterceptor<T> implements NestInterceptor<T, T[]> {
    */
   private readonly setLinkHeader = (linkOptions: LinkOptions): string => {
     const page: number = Number(linkOptions.page);
-    const hasNextPage: boolean = page <= Math.floor(linkOptions.totalDocs / Number(linkOptions.limit));
+    const hasNextPage: boolean = page < Math.ceil(linkOptions.totalDocs / Number(linkOptions.limit));
     const isFirstPage: boolean = page === 1;
 
     const linkObject: formatLinkHeader.Links = {
@@ -182,7 +182,7 @@ export class LinkHeaderInterceptor<T> implements NestInterceptor<T, T[]> {
     }
 
     if (endIndex > linkOptions.totalDocs) {
-      endIndex = linkOptions.totalDocs + 1;
+      endIndex = linkOptions.totalDocs;
     }
 
     return contentRange.format({

--- a/packages/pagination/test/add-link-header.test.ts
+++ b/packages/pagination/test/add-link-header.test.ts
@@ -111,7 +111,7 @@ describe('Tests related to the Link Header interceptor', () => {
       };
 
       expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
-      expect(res.header['content-range']).to.equal('data 1000-1015/1015');
+      expect(res.header['content-range']).to.equal('data 1000-1014/1015');
       expect(res.body.totalDocs).to.be.undefined;
       expect(res.body.resource).to.be.undefined;
       expect(res.body).to.be.an('array');
@@ -181,7 +181,7 @@ describe('Tests related to the Link Header interceptor', () => {
       };
 
       expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
-      expect(res.header['content-range']).to.equal('data 1000-1015/1015');
+      expect(res.header['content-range']).to.equal('data 1000-1014/1015');
       expect(res.body.totalDocs).to.be.undefined;
       expect(res.body.resource).to.be.undefined;
       expect(res.body).to.be.an('array');
@@ -247,7 +247,34 @@ describe('Tests related to the Link Header interceptor', () => {
       };
 
       expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
-      expect(res.header['content-range']).to.equal('data-custom-query 1000-1015/1015');
+      expect(res.header['content-range']).to.equal('data-custom-query 1000-1014/1015');
+      expect(res.body.totalDocs).to.be.undefined;
+      expect(res.body.resource).to.be.undefined;
+      expect(res.body).to.be.an('array');
+    });
+  });
+
+  describe('Tests with a limit of 1015', () => {
+    it('AD21 - should not add Link in headers for the next page', async () => {
+      const res: request.Response = await request(app.getHttpServer()).get('/data?page=1&per_page=1015').expect(200);
+
+      const expectedResult: formatLinkHeader.Links = {
+        first: {
+          url: '/data?page=1&per_page=1015',
+          page: '1',
+          per_page: '1015',
+          rel: 'first',
+        },
+        last: {
+          url: '/data?page=1&per_page=1015',
+          page: '1',
+          per_page: '1015',
+          rel: 'last',
+        },
+      };
+
+      expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
+      expect(res.header['content-range']).to.equal('data 0-1014/1015');
       expect(res.body.totalDocs).to.be.undefined;
       expect(res.body.resource).to.be.undefined;
       expect(res.body).to.be.an('array');


### PR DESCRIPTION
## Description

This solve two issues:

1. When your per page limit is equal to the rows count, the link header contains a non existent next page link.

2. Last page content range is wrong, for example having 15 items, the data range is something like 0-4/15 for the first page, 5-9/15 for the second page and 10-15/15 for the last page, to be consistent the last page content range should be 10-14/15