### PR TITLE
feat: set default limit

### DIFF
--- a/packages/pagination/README.md
+++ b/packages/pagination/README.md
@@ -70,7 +70,7 @@ Link: </data?page=1&per_page=100>; rel="first", </data?page=11&per_page=100>; re
 
 If you use MongoDB as your database, we also provide a `ParamDecorator` you can use to convert the request to a mongo query parameter.
 ```typescript
-import { LinkHeaderInterceptor, MongoPaginationParamDecorator, MongoPagination } from '@algoan/nestjs-pagination';
+import { LinkHeaderInterceptor, MongoPaginationParamDecorator, MongoPagination, Pageable } from '@algoan/nestjs-pagination';
 import { Controller, Get, UseInterceptors } from '@nestjs/common';
 
 @Controller()
@@ -83,8 +83,8 @@ class AppController {
    */
   @UseInterceptors(new LinkHeaderInterceptor({ resource: 'data' }))
   @Get('/data')
-  public async findAll(@MongoPaginationParamDecorator() pagination: MongoPagination ): Promise<{ totalDocs: number; resource: DataToReturn[] }> {
-    const data: DataToReturn = await model.find(pagination);
+  public async findAll(@MongoPaginationParamDecorator() pagination: MongoPagination ): Promise<Pageable<DataToReturn>> {
+    const data: DataToReturn[] = await model.find(pagination);
     const count: number = await model.count(pagination.filter);
 
     return { totalDocs: count, resource: data };
@@ -94,11 +94,11 @@ class AppController {
 
 ## Usage
 
-By default, the interceptor and the decorator will look for the query parameters `page` and  `per_page`. 
-You can also change the name of those parameters if you want, by passing a configuration object. Beware that if you use both the interceptor and the decorator, you need to pass the configuration to both of them.
+By default, the interceptor and the decorator will look for the query parameters `page` and  `per_page` (which is 100 by default).
+You can also change the name of those parameters and the default per page limit if you want, by passing a configuration object. Beware that if you use both the interceptor and the decorator, you need to pass the configuration to both of them.
 
 ```typescript
-new LinkHeaderInterceptor({ resource: 'data', pageName: '_page', perPageName: 'numberPerPage' })
+new LinkHeaderInterceptor({ resource: 'data', pageName: '_page', perPageName: 'numberPerPage', defaultLimit: 50 })
 
-@MongoPaginationParamDecorator({ pageName: '_page', perPageName: 'numberPerPage' })
+@MongoPaginationParamDecorator({ pageName: '_page', perPageName: 'numberPerPage', defaultLimit: 50  })
 ```

--- a/packages/pagination/src/index.ts
+++ b/packages/pagination/src/index.ts
@@ -1,2 +1,2 @@
-export { LinkHeaderInterceptor, Response } from './add-link-header.interceptor';
-export { MongoPaginationParamDecorator, MongoPagination, getMongoQuery } from './mongo-pagination-param.decorator';
+export { LinkHeaderInterceptor, Pageable, Response } from './add-link-header.interceptor';
+export { getMongoQuery, MongoPagination, MongoPaginationParamDecorator } from './mongo-pagination-param.decorator';

--- a/packages/pagination/src/mongo-pagination-param.decorator.ts
+++ b/packages/pagination/src/mongo-pagination-param.decorator.ts
@@ -18,15 +18,22 @@ export interface MongoPagination {
   project: [];
 }
 
-export const getMongoQuery = (
-  { pageName = 'page', perPageName = 'per_page' }: { pageName?: string; perPageName?: string } = {},
-  ctx: ExecutionContext,
-): MongoPagination => {
+/**
+ * Configuration Options
+ */
+interface MongoPaginationOptions {
+  pageName?: string;
+  perPageName?: string;
+  defaultLimit?: number;
+}
+
+export const getMongoQuery = (options: MongoPaginationOptions = {}, ctx: ExecutionContext): MongoPagination => {
   const req: Request = ctx.switchToHttp().getRequest();
+
+  const { pageName = 'page', perPageName = 'per_page', defaultLimit = DEFAULT_NUMBER_OF_RESULTS } = options;
+
   const page: number = !isNaN(Number(req.query[pageName])) ? Number(req.query[pageName]) : FIRST_PAGE;
-  const limit: number = !isNaN(Number(req.query[perPageName]))
-    ? Number(req.query[perPageName])
-    : DEFAULT_NUMBER_OF_RESULTS;
+  const limit: number = !isNaN(Number(req.query[perPageName])) ? Number(req.query[perPageName]) : defaultLimit;
   let filter: {};
   let sort: [];
   let project: [];

--- a/packages/pagination/test/add-link-header.test.ts
+++ b/packages/pagination/test/add-link-header.test.ts
@@ -254,6 +254,45 @@ describe('Tests related to the Link Header interceptor', () => {
     });
   });
 
+  describe('Test with custom default limit', () => {
+    it('AD21 - should successfully add Link with custom default limit', async () => {
+      const res: request.Response = await request(app.getHttpServer()).get('/data-limit?page=4').expect(200);
+
+      const expectedResult: formatLinkHeader.Links = {
+        first: {
+          url: '/data-limit?page=1&per_page=50',
+          page: '1',
+          per_page: '50',
+          rel: 'first',
+        },
+        last: {
+          url: '/data-limit?page=21&per_page=50',
+          page: '21',
+          per_page: '50',
+          rel: 'last',
+        },
+        next: {
+          url: '/data-limit?page=5&per_page=50',
+          page: '5',
+          per_page: '50',
+          rel: 'next',
+        },
+        prev: {
+          url: '/data-limit?page=3&per_page=50',
+          page: '3',
+          per_page: '50',
+          rel: 'prev',
+        },
+      };
+
+      expect(parseLinkHeader(res.header.link)).to.deep.equal(expectedResult);
+      expect(res.header['content-range']).to.equal('data 150-199/1015');
+      expect(res.body.totalDocs).to.be.undefined;
+      expect(res.body.resource).to.be.undefined;
+      expect(res.body).to.be.an('array');
+    });
+  });
+
   describe('Tests with a limit of 1015', () => {
     it('AD21 - should not add Link in headers for the next page', async () => {
       const res: request.Response = await request(app.getHttpServer()).get('/data?page=1&per_page=1015').expect(200);

--- a/packages/pagination/test/helpers.ts
+++ b/packages/pagination/test/helpers.ts
@@ -2,9 +2,9 @@ import { Controller, Get, INestApplication, Module, UseInterceptors } from '@nes
 import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
 import { CustomParamFactory } from '@nestjs/common/interfaces/features/custom-route-param-factory.interface';
 import { Test, TestingModule } from '@nestjs/testing';
+import { LinkHeaderInterceptor, MongoPagination, MongoPaginationParamDecorator, Pageable } from '../src';
 
-import { LinkHeaderInterceptor, MongoPagination, MongoPaginationParamDecorator } from '../src';
-
+const CUSTOM_LIMIT: number = 50;
 /**
  * Fake data format
  */
@@ -27,7 +27,7 @@ class FakeAppController {
    */
   @UseInterceptors(new LinkHeaderInterceptor({ resource: 'data' }))
   @Get('/data')
-  public async findAll(): Promise<{ totalDocs: number; resource: FakeDataToReturn[] }> {
+  public async findAll(): Promise<Pageable<FakeDataToReturn>> {
     const data: FakeDataToReturn[] = [];
     const maxDocuments: number = 1015;
 
@@ -43,7 +43,7 @@ class FakeAppController {
    */
   @UseInterceptors(new LinkHeaderInterceptor({ resource: 'resources' }))
   @Get('/resources')
-  public async find(): Promise<{ totalDocs: number; resource: FakeDataToReturn[] }> {
+  public async find(): Promise<Pageable<FakeDataToReturn>> {
     return { totalDocs: 0, resource: [] };
   }
 
@@ -54,8 +54,23 @@ class FakeAppController {
     new LinkHeaderInterceptor({ resource: 'data-custom-query', pageName: '_page', perPageName: 'numberPerPage' }),
   )
   @Get('/data-custom-query')
-  public async findAllWithCustomQuery(): Promise<{ totalDocs: number; resource: FakeDataToReturn[] }> {
+  public async findAllWithCustomQuery(): Promise<Pageable<FakeDataToReturn>> {
     return this.findAll();
+  }
+
+  /**
+   * Find all documents
+   */
+  @UseInterceptors(new LinkHeaderInterceptor({ resource: 'data', defaultLimit: CUSTOM_LIMIT }))
+  @Get('/data-limit')
+  public async findAllWithLimit(): Promise<Pageable<FakeDataToReturn>> {
+    const data: FakeDataToReturn[] = [];
+
+    for (let i: number = 0; i < CUSTOM_LIMIT; i++) {
+      data.push({ name: `doc_${i}`, index: i, createdAt: new Date() });
+    }
+
+    return { totalDocs: 1015, resource: data };
   }
 
   /**


### PR DESCRIPTION
### Improvements

Now we can set a default limit in case the `per_page` or whatever you named, is not present in the query params.

Also a new `Pageable` interface is exported to use in your Controller responses

Some code examples:
![dto](https://user-images.githubusercontent.com/371939/96817838-8d64ad00-13f6-11eb-95c8-7cef6c8aba85.png)
![code](https://user-images.githubusercontent.com/371939/96817839-8fc70700-13f6-11eb-9367-afac4c2ef506.png)

