### PR TITLE
fix: subscribe event message handlers only

### DIFF
--- a/packages/google-pubsub-microservice/src/GooglePubSubServer.ts
+++ b/packages/google-pubsub-microservice/src/GooglePubSubServer.ts
@@ -39,7 +39,10 @@ export class GCPubSubServer extends Server implements CustomTransportStrategy {
     this.gcClient = gcPubSub;
     const handlers: Promise<void>[] = [];
 
-    for (const subscriptionName of this.messageHandlers.keys()) {
+    this.messageHandlers.forEach((messageHandler: MessageHandler, subscriptionName: string) => {
+      if (!messageHandler.isEventHandler) {
+        return;
+      }
       this.logger.debug(`Registered new subscription "${subscriptionName}"`);
 
       handlers.push(
@@ -49,7 +52,7 @@ export class GCPubSubServer extends Server implements CustomTransportStrategy {
           options: this.options?.listenOptions,
         }),
       );
-    }
+    });
 
     Promise.all(handlers).then(callback).catch(this.handleError);
   }


### PR DESCRIPTION
### Description

In a NestJS app with other microservice (for example, gRPC controllers), the PubSub consumer tries to subscribe to all the message handlers.

### Bug fixed

**Before**

- The app does not start because the subscription name has invalid characters for those handlers
- Those subscriptions should not be created

**Now**

- The consumer only subscribes to handlers defined with the `@EventPattern` decorator.
