### PR TITLE
feat: be able to filter topic names to subscribe

### DIFF
--- a/packages/google-pubsub-microservice/README.md
+++ b/packages/google-pubsub-microservice/README.md
@@ -37,7 +37,7 @@ async function bootstrap() {
   }
 
   const app: INestMicroservice = await NestFactory.create(AppModule, {
-    strategy
+    strategy: new GCPubSubServer(options)
   })
 
   await app.listen(() => console.log('Server running!'));
@@ -81,6 +81,7 @@ Create a new Server instance of Google PubSub. It retrieves all message handlers
 
 - `options`: Algoan PubSub options. More information [here](https://github.com/algoan/pubsub/#pubsubfactorycreate-transport-options-).
 - `options.listenOptions`: Global options which will be applied to all subscriptions.
+- `options.topicsNames`: Only subscribe to topics included in this whitelist.
 
 ## Other NestJS Google Cloud PubSub server
 

--- a/packages/google-pubsub-microservice/src/GooglePubSubServer.ts
+++ b/packages/google-pubsub-microservice/src/GooglePubSubServer.ts
@@ -24,7 +24,7 @@ export class GCPubSubServer extends Server implements CustomTransportStrategy {
   protected readonly logger: Logger = new Logger(GCPubSubServer.name);
 
   constructor(
-    private readonly options?: GooglePubSubOptions & { listenOptions?: GCListenOptions } & { topicsNames?: string[] },
+    private readonly options?: GooglePubSubOptions & { listenOptions?: GCListenOptions; topicsNames?: string[] },
   ) {
     super();
   }

--- a/packages/google-pubsub-microservice/src/GooglePubSubServer.ts
+++ b/packages/google-pubsub-microservice/src/GooglePubSubServer.ts
@@ -23,7 +23,9 @@ export class GCPubSubServer extends Server implements CustomTransportStrategy {
    */
   protected readonly logger: Logger = new Logger(GCPubSubServer.name);
 
-  constructor(private readonly options?: GooglePubSubOptions & { listenOptions?: GCListenOptions }) {
+  constructor(
+    private readonly options?: GooglePubSubOptions & { listenOptions?: GCListenOptions } & { topicsNames?: string[] },
+  ) {
     super();
   }
 
@@ -40,6 +42,9 @@ export class GCPubSubServer extends Server implements CustomTransportStrategy {
     const handlers: Promise<void>[] = [];
 
     for (const subscriptionName of this.messageHandlers.keys()) {
+      if (this.options?.topicsNames && !this.options?.topicsNames?.includes(subscriptionName)) {
+        continue;
+      }
       this.logger.debug(`Registered new subscription "${subscriptionName}"`);
 
       handlers.push(

--- a/packages/google-pubsub-microservice/src/GooglePubSubServer.ts
+++ b/packages/google-pubsub-microservice/src/GooglePubSubServer.ts
@@ -42,7 +42,7 @@ export class GCPubSubServer extends Server implements CustomTransportStrategy {
     const handlers: Promise<void>[] = [];
 
     for (const subscriptionName of this.messageHandlers.keys()) {
-      if (this.options?.topicsNames && !this.options?.topicsNames?.includes(subscriptionName)) {
+      if (this.options?.topicsNames !== undefined && !this.options?.topicsNames?.includes(subscriptionName)) {
         continue;
       }
       this.logger.debug(`Registered new subscription "${subscriptionName}"`);

--- a/packages/google-pubsub-microservice/test/GooglePubSubServer.test.ts
+++ b/packages/google-pubsub-microservice/test/GooglePubSubServer.test.ts
@@ -1,7 +1,7 @@
 import * as delay from 'delay';
 
 import { GCPubSubServer } from '../src';
-import { SUBSCRIPTION_NAME } from './test-app/app.controller';
+import { SUBSCRIPTION_NAME, SUBSCRIPTION_NAME_2 } from './test-app/app.controller';
 import { AppService } from './test-app/app.service';
 import { getTestingApplication } from './test-app/main';
 
@@ -31,6 +31,7 @@ describe('GooglePubSubServer', () => {
   it('GCPSS01 - should properly listen to a subscription - cb call', async (done: jest.DoneCallback) => {
     const server: GCPubSubServer = new GCPubSubServer({
       projectId: 'algoan-test',
+      topicsNames: [SUBSCRIPTION_NAME],
     });
     const { app } = await getTestingApplication(server);
     /**
@@ -49,6 +50,7 @@ describe('GooglePubSubServer', () => {
     const server: GCPubSubServer = new GCPubSubServer({
       subscriptionsPrefix: 'test-app',
       projectId: 'algoan-test',
+      topicsNames: [SUBSCRIPTION_NAME],
       listenOptions: {
         subscriptionOptions: {
           sub: {
@@ -77,6 +79,7 @@ describe('GooglePubSubServer', () => {
   it('GCPSS03 - Emit an event and test if it is received', async (done: jest.DoneCallback) => {
     const server: GCPubSubServer = new GCPubSubServer({
       projectId: 'algoan-test',
+      topicsNames: [SUBSCRIPTION_NAME],
     });
     const { app, module } = await getTestingApplication(server);
     const appService: AppService = module.get(AppService);
@@ -99,6 +102,25 @@ describe('GooglePubSubServer', () => {
       await delay(100);
       expect(spy).toHaveBeenCalledTimes(1);
 
+      done();
+    });
+  });
+
+  it('GCPSS04 - should properly listen to all subscriptions - cb call', async (done: jest.DoneCallback) => {
+    const server: GCPubSubServer = new GCPubSubServer({
+      projectId: 'algoan-test',
+    });
+    const { app } = await getTestingApplication(server);
+    /**
+     * After launching the application, ensure that all subscriptions have been created
+     */
+    app.listen(async () => {
+      expect(server.gcClient.subscriptions.get(SUBSCRIPTION_NAME)).toBeDefined();
+      expect(await server.gcClient.client.subscription(SUBSCRIPTION_NAME).exists()).toEqual([true]);
+      expect(server.gcClient.subscriptions.get(SUBSCRIPTION_NAME_2)).toBeDefined();
+      expect(await server.gcClient.client.subscription(SUBSCRIPTION_NAME_2).exists()).toEqual([true]);
+
+      await app.close();
       done();
     });
   });

--- a/packages/google-pubsub-microservice/test/test-app/app.controller.ts
+++ b/packages/google-pubsub-microservice/test/test-app/app.controller.ts
@@ -4,6 +4,7 @@ import { EventPattern, Payload } from '@nestjs/microservices';
 import { AppService } from './app.service';
 
 export const SUBSCRIPTION_NAME: string = 'test_event';
+export const SUBSCRIPTION_NAME_2: string = 'test_event_2';
 
 /**
  * Fake app controller
@@ -18,6 +19,15 @@ export class AppController {
    */
   @EventPattern(SUBSCRIPTION_NAME)
   public async handleTestEvent(@Payload() data: EmittedMessage<{ hello: string }>): Promise<void> {
+    this.appService.handleTestEvent(data);
+  }
+
+  /**
+   * Handle the test event (2)
+   * @param data Payload sent
+   */
+  @EventPattern(SUBSCRIPTION_NAME_2)
+  public async handleTestEvent2(@Payload() data: EmittedMessage<{ hello: string }>): Promise<void> {
     this.appService.handleTestEvent(data);
   }
 }


### PR DESCRIPTION
## Description

In google-pubsub-microservice, the `GCPubSubServer` class tries to subscribe to every handler configured in the NestJS application.

Sometimes, there are more microservice handlers defined and those ones must not subscribe.

### Features

Include a configuration option `topicsNames: string[]` to be able to filter the handlers to subscribe. This option is optional, so the previous behavior is kept.
