### PR TITLE
Change the default value of "sort" and "project" fields in MongoPagination

### DIFF
--- a/packages/pagination/src/mongo-pagination-param.decorator.ts
+++ b/packages/pagination/src/mongo-pagination-param.decorator.ts
@@ -14,8 +14,8 @@ export interface MongoPagination {
   };
   limit: number;
   skip: number;
-  sort: [];
-  project: [];
+  sort: {};
+  project: {};
 }
 
 /**
@@ -35,13 +35,13 @@ export const getMongoQuery = (options: MongoPaginationOptions = {}, ctx: Executi
   const page: number = !isNaN(Number(req.query[pageName])) ? Number(req.query[pageName]) : FIRST_PAGE;
   const limit: number = !isNaN(Number(req.query[perPageName])) ? Number(req.query[perPageName]) : defaultLimit;
   let filter: {};
-  let sort: [];
-  let project: [];
+  let sort: {};
+  let project: {};
 
   try {
     filter = req.query.filter !== undefined ? JSON.parse(req.query.filter as string) : {};
-    sort = req.query.sort !== undefined ? JSON.parse(req.query.sort as string) : [];
-    project = req.query.project !== undefined ? JSON.parse(req.query.project as string) : [];
+    sort = req.query.sort !== undefined ? JSON.parse(req.query.sort as string) : {};
+    project = req.query.project !== undefined ? JSON.parse(req.query.project as string) : {};
   } catch (exception) {
     throw new BadRequestException('Either the sort, filter or project parameter cannot be parsed');
   }

--- a/packages/pagination/src/mongo-pagination-param.decorator.ts
+++ b/packages/pagination/src/mongo-pagination-param.decorator.ts
@@ -14,9 +14,19 @@ export interface MongoPagination {
   };
   limit: number;
   skip: number;
-  sort: {};
-  project: {};
+  sort?: {
+    [key: string]: SortValue;
+  };
+  project?: {
+    [key: string]: 0 | 1;
+  };
 }
+
+/**
+ * Sort values available for Mongoose
+ * Ref: https://mongoosejs.com/docs/api/query.html#query_Query-sort
+ */
+type SortValue = 'asc' | 'desc' | 'ascending' | 'descending' | 1 | -1;
 
 /**
  * Configuration Options

--- a/packages/pagination/test/mongo-pagination-param.unit.test.ts
+++ b/packages/pagination/test/mongo-pagination-param.unit.test.ts
@@ -25,8 +25,8 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
       filter: {},
       limit: 10,
       skip: 0,
-      sort: [],
-      project: [],
+      sort: {},
+      project: {},
     });
   });
 
@@ -39,13 +39,21 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
       filter: {},
       limit: 20,
       skip: 20,
-      sort: [],
-      project: [],
+      sort: {},
+      project: {},
     });
   });
 
   it('MPPD03 - should successfully parse filters', () => {
-    req = { query: { page: '1', per_page: '20', filter: '{"key": "value"}', sort: '[]' } };
+    req = {
+      query: {
+        page: '1',
+        per_page: '20',
+        filter: '{"key": "value"}',
+        sort: '{"key": 1, "value": -1}',
+        project: '{"key": 1, "value": 1}',
+      },
+    };
 
     const result: MongoPagination = getMongoQuery({}, ctx as ExecutionContext);
 
@@ -53,8 +61,8 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
       filter: { key: 'value' },
       limit: 20,
       skip: 0,
-      sort: [],
-      project: [],
+      sort: { key: 1, value: -1 },
+      project: { key: 1, value: 1 },
     });
   });
 
@@ -65,7 +73,7 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
   });
 
   it('MPPD05 - should handle custom query params name', () => {
-    req = { query: { _page: '1', _per_page: '20', filter: '{"key": "value"}', sort: '[]' } };
+    req = { query: { _page: '1', _per_page: '20', filter: '{"key": "value"}', sort: '{}' } };
 
     const result: MongoPagination = getMongoQuery(
       { pageName: '_page', perPageName: '_per_page' },
@@ -76,13 +84,13 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
       filter: { key: 'value' },
       limit: 20,
       skip: 0,
-      sort: [],
-      project: [],
+      sort: {},
+      project: {},
     });
   });
 
   it('MPPD06 - should successfully parse filters (per_page: 0)', () => {
-    req = { query: { page: '1', per_page: '0', filter: '{"key": "value"}', sort: '[]' } };
+    req = { query: { page: '1', per_page: '0', filter: '{"key": "value"}', sort: '{}' } };
 
     const result: MongoPagination = getMongoQuery({}, ctx as ExecutionContext);
 
@@ -90,8 +98,8 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
       filter: { key: 'value' },
       limit: 0,
       skip: 0,
-      sort: [],
-      project: [],
+      sort: {},
+      project: {},
     });
   });
 });


### PR DESCRIPTION
This PR aims to fix the following issue:
https://github.com/algoan/nestjs-components/issues/112

BREAKING CHANGE: 
* Modify the default value of `sort` and `project` fields in MongoPagination from `[]`
to `{}` to conform with the Mongoose documentation.
* Make those 2 fields obligatory and specify explicitly their value range

As a result, if you instantiate a `MongoPagination` object in your program without obtaining it from `@MongoPaginationParamDecorator`, you need to set fields `sort` and `project` as `{}` instead of `[]` or just omitting them