### PR TITLE
Allow filtering the keys in the query

### DIFF
--- a/packages/pagination/src/mongo-pagination-param.decorator.ts
+++ b/packages/pagination/src/mongo-pagination-param.decorator.ts
@@ -35,13 +35,18 @@ interface MongoPaginationOptions {
   pageName?: string;
   perPageName?: string;
   defaultLimit?: number;
-  exclude?: string[];
+  excludedKeys?: string[];
 }
 
 export const getMongoQuery = (options: MongoPaginationOptions = {}, ctx: ExecutionContext): MongoPagination => {
   const req: Request = ctx.switchToHttp().getRequest();
 
-  const { pageName = 'page', perPageName = 'per_page', defaultLimit = DEFAULT_NUMBER_OF_RESULTS, exclude } = options;
+  const {
+    pageName = 'page',
+    perPageName = 'per_page',
+    defaultLimit = DEFAULT_NUMBER_OF_RESULTS,
+    excludedKeys = ['$where', 'mapreduce', '$accumulator', '$function'],
+  } = options;
 
   const page: number = !isNaN(Number(req.query[pageName])) ? Number(req.query[pageName]) : FIRST_PAGE;
   const limit: number = !isNaN(Number(req.query[perPageName])) ? Number(req.query[perPageName]) : defaultLimit;
@@ -58,8 +63,8 @@ export const getMongoQuery = (options: MongoPaginationOptions = {}, ctx: Executi
     throw new BadRequestException('Either the sort, filter or project parameter cannot be parsed');
   }
 
-  if (Array.isArray(exclude)) {
-    const excludeStrings: string[] = exclude.filter((elem: unknown): boolean => typeof elem === 'string');
+  if (Array.isArray(excludedKeys)) {
+    const excludeStrings: string[] = excludedKeys.filter((elem: unknown): boolean => typeof elem === 'string');
 
     if (excludeStrings.length > 0) {
       excludePattern = buildExcludePattern(excludeStrings);

--- a/packages/pagination/test/helpers.ts
+++ b/packages/pagination/test/helpers.ts
@@ -86,7 +86,9 @@ class FakeAppController {
    * Test the pagination decorator
    */
   @Get('/pagination')
-  public async testPagination(@MongoPaginationParamDecorator() pagination: MongoPagination): Promise<{}> {
+  public async testPagination(
+    @MongoPaginationParamDecorator({ exclude: ['$where'] }) pagination: MongoPagination,
+  ): Promise<{}> {
     return { pagination };
   }
 }

--- a/packages/pagination/test/helpers.ts
+++ b/packages/pagination/test/helpers.ts
@@ -86,9 +86,7 @@ class FakeAppController {
    * Test the pagination decorator
    */
   @Get('/pagination')
-  public async testPagination(
-    @MongoPaginationParamDecorator({ exclude: ['$where'] }) pagination: MongoPagination,
-  ): Promise<{}> {
+  public async testPagination(@MongoPaginationParamDecorator({}) pagination: MongoPagination): Promise<{}> {
     return { pagination };
   }
 }

--- a/packages/pagination/test/mongo-pagination-param.e2e.test.ts
+++ b/packages/pagination/test/mongo-pagination-param.e2e.test.ts
@@ -19,7 +19,6 @@ describe('E2e tests related to the MongoPagination ParamDecorator', () => {
     it('MPPDE01 - should successfully create the mongoQuery from the request', async () => {
       const res: request.Response = await request(app.getHttpServer())
         .get(
-          // /pagination?page=5&per_page=35&sort={"createdAt":-1}&project={"id":1,"applicationId":1}&filter={"status":{"$options":"i","$regex":"ACCEPTED"},"$where":"function () { return true; }"}
           '/pagination?page=5&per_page=35&sort=%7B%22createdAt%22%3A-1%7D&project=%7B%22id%22%3A1%2C%22applicationId%22%3A1%7D&filter=%7B%22status%22%3A%7B%22%24options%22%3A%22i%22%2C%22%24regex%22%3A%22ACCEPTED%22%7D%2C%22%24where%22%3A%22function%20%28%29%20%7B%20return%20true%3B%20%7D%22%7D',
         )
         .expect(200);

--- a/packages/pagination/test/mongo-pagination-param.e2e.test.ts
+++ b/packages/pagination/test/mongo-pagination-param.e2e.test.ts
@@ -19,7 +19,8 @@ describe('E2e tests related to the MongoPagination ParamDecorator', () => {
     it('MPPDE01 - should successfully create the mongoQuery from the request', async () => {
       const res: request.Response = await request(app.getHttpServer())
         .get(
-          '/pagination?page=5&per_page=35&sort=%7B%22createdAt%22%3A-1%7D&project=%7B%22id%22%3A1%2C%22applicationId%22%3A1%7D&filter=%7B%22status%22%3A%7B%22%24options%22%3A%22i%22%2C%22%24regex%22%3A%22ACCEPTED%22%7D%7D',
+          // /pagination?page=5&per_page=35&sort={"createdAt":-1}&project={"id":1,"applicationId":1}&filter={"status":{"$options":"i","$regex":"ACCEPTED"},"$where":"function () { return true; }"}
+          '/pagination?page=5&per_page=35&sort=%7B%22createdAt%22%3A-1%7D&project=%7B%22id%22%3A1%2C%22applicationId%22%3A1%7D&filter=%7B%22status%22%3A%7B%22%24options%22%3A%22i%22%2C%22%24regex%22%3A%22ACCEPTED%22%7D%2C%22%24where%22%3A%22function%20%28%29%20%7B%20return%20true%3B%20%7D%22%7D',
         )
         .expect(200);
 

--- a/packages/pagination/test/mongo-pagination-param.unit.test.ts
+++ b/packages/pagination/test/mongo-pagination-param.unit.test.ts
@@ -102,4 +102,29 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
       project: {},
     });
   });
+
+  it('MPPD07 - should successfully sanitize the keys', () => {
+    req = {
+      query: {
+        page: '1',
+        per_page: '0',
+        filter:
+          '{"key": "value", "mapreduce": "", "$expr": {"$function": { "body": "function () { return true; }", "args": [], "lang": "js" } } }',
+        project: '{"$where": "function () { return true; }"}',
+      },
+    };
+
+    const result: MongoPagination = getMongoQuery(
+      { exclude: ['$where', 'mapreduce', '$accumulator', '$function'] },
+      ctx as ExecutionContext,
+    );
+
+    expect(result).to.deep.equal({
+      filter: { key: 'value', $expr: {} },
+      limit: 0,
+      skip: 0,
+      sort: {},
+      project: {},
+    });
+  });
 });

--- a/packages/pagination/test/mongo-pagination-param.unit.test.ts
+++ b/packages/pagination/test/mongo-pagination-param.unit.test.ts
@@ -115,7 +115,7 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
     };
 
     const result: MongoPagination = getMongoQuery(
-      { exclude: ['$where', 'mapreduce', '$accumulator', '$function'] },
+      { excludedKeys: ['$where', 'mapreduce', '$function'] },
       ctx as ExecutionContext,
     );
 


### PR DESCRIPTION
### [FEAT] Key filtering

This PR implements a feature which allows you to provide an array of key names in an option parameter called `exclude`  of the `@MongoPaginationParamDecorator()` decorator to filter the keys extracted from the request query.

As a result, all the keys belonging to the list will be removed from the resulting `MongoPagination` object. For example, you could use `@MongoPaginationParamDecorator( { exclude: ["$where", "$exists", accumulator] } ) pagination: MongoPagination` in the handler to exclude the corresponding fields you don't want to receive from the request query.

The principal purpose of this feature is to prevent the MongoDB injection from the client-side using Javascript code. As indicated in the MongoDB documentation, there are 4 following MongoDB operations that permit running arbitrary JavaScript expressions directly on the server:

* `$where`
* `mapreduce`
* `$accumulator`
* `$function`

So, it's recommended to remove them from the request query if you don't need them to prevent users from submitting malicious JavaScript.

https://docs.mongodb.com/manual/faq/fundamentals/#how-does-mongodb-address-sql-or-query-injection

### [FIX] Allow providing options parameters to the decorator
This PR also aims to fix an existing bug which prevents providing options params to the `@MongoPaginationParamDecorator()` decorator. In fact, the following type annotation is not correct because it indicates the decorator receives no parameter:
```typescript
export const MongoPaginationParamDecorator: () => ParameterDecorator = createParamDecorator(getMongoQuery);
```
The current e2e tests haven't covered the case there are options params provided to the decorator. The unit tests have covered but they tested the function `getMongoQuery(options: MongoPaginationOptions = {}, ctx: ExecutionContext)` directly, not the decorator `MongoPaginationParamDecorator`.

I've just removed the TS annotation and disabled the TSLint rule to make it work because I haven't known how to annotate the type for that decorator correctly. The declaration of `createParamDecorator` of Nest is so complicated:
```typescript
export declare function createParamDecorator<FactoryData = any, FactoryInput = any, FactoryOutput = any>(factory: CustomParamFactory<FactoryData, FactoryInput, FactoryOutput>, enhancers?: ParamDecoratorEnhancer[]): (...dataOrPipes: (Type<PipeTransform> | PipeTransform | FactoryData)[]) => ParameterDecorator;
```