### PR TITLE
Set default autoAck for listenOptions of GCPubSub

### DIFF
--- a/packages/google-pubsub-microservice/src/GooglePubSubServer.ts
+++ b/packages/google-pubsub-microservice/src/GooglePubSubServer.ts
@@ -51,7 +51,10 @@ export class GCPubSubServer extends Server implements CustomTransportStrategy {
         gcPubSub.listen(subscriptionName, {
           onMessage: this.handleMessage(subscriptionName),
           onError: this.handleError,
-          options: this.options?.listenOptions,
+          options: {
+            autoAck: true,
+            ...this.options?.listenOptions,
+          },
         }),
       );
     }


### PR DESCRIPTION
Currently the default option `autoAck: true` isn't set correctly in the default parameter of the `listen()` method of GoogleCloudPubSub.

Instead, we could provide a default property `autoAck:true` in the options argument passed to the `listen()` call in the implementation of GCPubSubServer. The user can override that property by providing another value for `autoAck` in `listenOptions`.