### PR TITLE
fix: the relentless spam if options.debug !== true

### DIFF
--- a/packages/google-pubsub-client/src/GooglePubSubClient.ts
+++ b/packages/google-pubsub-client/src/GooglePubSubClient.ts
@@ -31,7 +31,7 @@ export class GCPubSubClient extends ClientProxy {
    */
   public async connect(): Promise<void> {
     const isPubSubInstanceExisting: boolean = this.pubSub !== undefined;
-    this.logger.debug(
+    this.options?.debug && this.logger.debug(
       {
         isPubSubInstanceExisting,
       },
@@ -52,7 +52,7 @@ export class GCPubSubClient extends ClientProxy {
    * Close the connection with the client
    */
   public async close(): Promise<void> {
-    this.logger.debug('Closing the GooglePubSubClient Proxy');
+    this.options?.debug && this.logger.debug('Closing the GooglePubSubClient Proxy');
     if (this.pubSub !== undefined) {
       await this.pubSub.client.close();
     }
@@ -70,7 +70,7 @@ export class GCPubSubClient extends ClientProxy {
     }
 
     const pattern: string = this.normalizePattern(_packet.pattern);
-    this.logger.debug(
+    this.options?.debug && this.logger.debug(
       {
         pattern,
         data: _packet.data,

--- a/packages/google-pubsub-client/src/GooglePubSubClient.ts
+++ b/packages/google-pubsub-client/src/GooglePubSubClient.ts
@@ -31,12 +31,14 @@ export class GCPubSubClient extends ClientProxy {
    */
   public async connect(): Promise<void> {
     const isPubSubInstanceExisting: boolean = this.pubSub !== undefined;
-    this.options?.debug && this.logger.debug(
+    if ( this.options?.debug === true ) {
+      this.logger.debug(
       {
         isPubSubInstanceExisting,
       },
       `Trying to connect to the Google PubSub Client Proxy`,
-    );
+      );
+    }
 
     if (isPubSubInstanceExisting) {
       return;
@@ -52,11 +54,13 @@ export class GCPubSubClient extends ClientProxy {
    * Close the connection with the client
    */
   public async close(): Promise<void> {
-    this.options?.debug && this.logger.debug('Closing the GooglePubSubClient Proxy');
-    if (this.pubSub !== undefined) {
-      await this.pubSub.client.close();
+    if ( this.options?.debug === true ) {
+      this.logger.debug('Closing the GooglePubSubClient Proxy');
+      if (this.pubSub !== undefined) {
+        await this.pubSub.client.close();
+      }
+      this.pubSub = undefined;
     }
-    this.pubSub = undefined;
   }
 
   /**
@@ -70,13 +74,15 @@ export class GCPubSubClient extends ClientProxy {
     }
 
     const pattern: string = this.normalizePattern(_packet.pattern);
-    this.options?.debug && this.logger.debug(
-      {
-        pattern,
-        data: _packet.data,
-      },
-      'Emitting an event through the GCPubSubClient',
-    );
+    if ( this.options?.debug === true ) {
+       this.logger.debug(
+        {
+          pattern,
+          data: _packet.data,
+        },
+        'Emitting an event through the GCPubSubClient',
+      );
+    }
 
     return this.pubSub.emit(pattern, _packet.data);
   }


### PR DESCRIPTION
## Honor debug param in config

> Minor tweak to prevent console spam in development mode. 

### Improvements

> Added options.debug test prior to logger.debug. Otherwise, irrespective of options.debug, your console gets easily flooded.
