### PR TITLE
[FIX]: Change the default limit for pagination results to 200

### DIFF
--- a/packages/pagination/src/mongo-pagination-param.decorator.ts
+++ b/packages/pagination/src/mongo-pagination-param.decorator.ts
@@ -2,7 +2,7 @@ import { BadRequestException, createParamDecorator, ExecutionContext } from '@ne
 import { Request } from 'express';
 
 const FIRST_PAGE: number = 1;
-const DEFAULT_NUMBER_OF_RESULTS: number = 10;
+const DEFAULT_NUMBER_OF_RESULTS: number = 200;
 
 /**
  * Mongo query

--- a/packages/pagination/test/mongo-pagination-param.e2e.test.ts
+++ b/packages/pagination/test/mongo-pagination-param.e2e.test.ts
@@ -47,9 +47,9 @@ describe('E2e tests related to the MongoPagination ParamDecorator', () => {
 
       expect(res.body.pagination).to.deep.equal({
         filter: {},
-        limit: 10,
+        limit: 200,
         project: {},
-        skip: 40,
+        skip: 800,
         sort: {},
       });
     });

--- a/packages/pagination/test/mongo-pagination-param.unit.test.ts
+++ b/packages/pagination/test/mongo-pagination-param.unit.test.ts
@@ -23,7 +23,7 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
 
     expect(result).to.deep.equal({
       filter: {},
-      limit: 10,
+      limit: 200,
       skip: 0,
       sort: {},
       project: {},


### PR DESCRIPTION
## Description

Changing the default value for the number of results returned in the pagination to 200