### PR TITLE
feat(pubsubclient): be able to add message attributes

### DIFF
--- a/packages/google-pubsub-client/src/GooglePubSubClient.ts
+++ b/packages/google-pubsub-client/src/GooglePubSubClient.ts
@@ -73,7 +73,7 @@ export class GCPubSubClient extends ClientProxy {
       return undefined;
     }
 
-    let opts: { metadata?: { [key: string]: string } } = {};
+    const opts: { metadata?: { [key: string]: string } } = {};
     if (
       this.options?.messageMetadataKey !== undefined &&
       _packet.data[this.options?.messageMetadataKey] !== undefined

--- a/packages/google-pubsub-client/src/GooglePubSubClient.ts
+++ b/packages/google-pubsub-client/src/GooglePubSubClient.ts
@@ -2,7 +2,7 @@ import { GCPubSub, GooglePubSubOptions, PubSubFactory, Transport } from '@algoan
 import { Logger } from '@nestjs/common';
 import { ClientProxy, ReadPacket } from '@nestjs/microservices';
 
-export type GCPubSubClientOptions = GooglePubSubOptions & {messageMetadataKey?: string};
+export type GCPubSubClientOptions = GooglePubSubOptions & { messageMetadataKey?: string };
 /**
  * Algoan pub sub client
  */
@@ -72,11 +72,15 @@ export class GCPubSubClient extends ClientProxy {
     if (this.pubSub === undefined) {
       return undefined;
     }
-    
-    let opts = {};
-    if (this.options?.messageMetadataKey !== undefined && _packet.data[this.options?.messageMetadataKey] !== undefined) {
-      opts = {metadata: ..._packet.data[this.options?.messageMetadataKey]};
-      delete _packet.data[this.options?.messageMetadataKey]
+
+    let opts: { metadata?: { [key: string]: string } } = {};
+    if (
+      this.options?.messageMetadataKey !== undefined &&
+      _packet.data[this.options?.messageMetadataKey] !== undefined
+    ) {
+      opts.metadata = _packet.data[this.options?.messageMetadataKey];
+      // tslint:disable-next-line: no-dynamic-delete
+      delete _packet.data[this.options?.messageMetadataKey];
     }
 
     const pattern: string = this.normalizePattern(_packet.pattern);
@@ -85,7 +89,7 @@ export class GCPubSubClient extends ClientProxy {
         {
           pattern,
           data: _packet.data,
-          opts: opts,
+          opts,
         },
         'Emitting an event through the GCPubSubClient',
       );


### PR DESCRIPTION
## Description

When publishing messages sometimes is needed to add attributes to the message. The the PubSub library support to send an options parameter in the `emit` method but the NestJS emitter doesn't, so the attributes to be included in the message should be send as a part of the message.

### Features

To support adding custom attributes during emitting, a configuration option can be defined in order to remove from the message that property and to add the values as attributes.
