### PR TITLE
fix(deps): support @algoan/pubsub 5.x.x as peer dependency

### DIFF
--- a/packages/google-pubsub-client/package-lock.json
+++ b/packages/google-pubsub-client/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "@algoan/nestjs-google-pubsub-client",
-      "version": "0.4.0",
+      "version": "0.4.2",
       "license": "ISC",
       "devDependencies": {
         "@algoan/nestjs-google-pubsub-microservice": "file:../google-pubsub-microservice"
       },
       "peerDependencies": {
-        "@algoan/pubsub": "^4.x.x",
+        "@algoan/pubsub": ">=4.x.x",
         "@nestjs/common": ">=8",
         "@nestjs/core": ">=8",
         "@nestjs/microservices": ">=8",
@@ -21,7 +21,7 @@
     },
     "../google-pubsub-microservice": {
       "name": "@algoan/nestjs-google-pubsub-microservice",
-      "version": "3.0.1",
+      "version": "3.0.3",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {

--- a/packages/google-pubsub-client/package.json
+++ b/packages/google-pubsub-client/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/algoan/nestjs-components/issues"
   },
   "peerDependencies": {
-    "@algoan/pubsub": "^4.x.x",
+    "@algoan/pubsub": ">=4.x.x",
     "@nestjs/common": ">=8",
     "@nestjs/core": ">=8",
     "@nestjs/microservices": ">=8",


### PR DESCRIPTION
## Description
Add support for new `@algoan/pubsub` `5.0.0` package as a peer dependency to the `@algoan/nestjs-google-pubsub-client` package.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was trying to upgrade to use `@algoan/pubsub` `5.0.0` in a project where I use `@algoan/nestjs-google-pubsub-client@0.4.2` and ran into issues with peer dependencies.

![image](https://user-images.githubusercontent.com/20227290/180843025-9d906860-306b-4007-883e-5e97bfac4c34.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
