### PR TITLE
Fix URLs to use perPageName instead of &limit

### DIFF
--- a/packages/pagination/src/add-pagination-body.interceptor.ts
+++ b/packages/pagination/src/add-pagination-body.interceptor.ts
@@ -94,7 +94,7 @@ export class PaginationBodyInterceptor<T> implements NestInterceptor<DataToPagin
     project?: unknown,
   ): string => {
     // tslint:disable-next-line
-    let url = `${path}?page=${page}&${perPageName}=${limit}`;
+    let url = `${path}?page=${page}&${this.perPageName}=${limit}`;
 
     if (filter !== undefined) {
       url += `&filter=${filter}`;

--- a/packages/pagination/src/add-pagination-body.interceptor.ts
+++ b/packages/pagination/src/add-pagination-body.interceptor.ts
@@ -94,7 +94,7 @@ export class PaginationBodyInterceptor<T> implements NestInterceptor<DataToPagin
     project?: unknown,
   ): string => {
     // tslint:disable-next-line
-    let url = `${path}?page=${page}&limit=${limit}`;
+    let url = `${path}?page=${page}&${perPageName}=${limit}`;
 
     if (filter !== undefined) {
       url += `&filter=${filter}`;


### PR DESCRIPTION
If we use `&limit` instead of the user-defined `perPageName`, the URLs generated will wrongly use `limit`, and thus not work.

## Description
<!--- Describe your changes in detail -->
Code wrongly uses static &limit property in the URL builder, leading to wrong URLs being generated if the user uses something other than "limit" as their `perPageName`.

This might break existing codebases if they have somehow adapted to using limit (eg. with a custom interceptor that changes `limit` to their desired perPageName)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
