### PR TITLE
[nestjs-pagination] Throw on invalid limit (negative or 0)

### DIFF
--- a/packages/pagination/src/mongo-pagination-param.decorator.ts
+++ b/packages/pagination/src/mongo-pagination-param.decorator.ts
@@ -55,6 +55,10 @@ export const getMongoQuery = (options: MongoPaginationOptions = {}, ctx: Executi
   let project: {};
   let excludePattern: string = '';
 
+  if (limit <= 0) {
+    throw new BadRequestException(`${perPageName} should be a strictly positive number, got: ${limit}`);
+  }
+
   try {
     filter = req.query.filter !== undefined ? JSON.parse(req.query.filter as string) : {};
     sort = req.query.sort !== undefined ? JSON.parse(req.query.sort as string) : {};

--- a/packages/pagination/test/mongo-pagination-param.unit.test.ts
+++ b/packages/pagination/test/mongo-pagination-param.unit.test.ts
@@ -89,14 +89,14 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
     });
   });
 
-  it('MPPD06 - should successfully parse filters (per_page: 0)', () => {
-    req = { query: { page: '1', per_page: '0', filter: '{"key": "value"}', sort: '{}' } };
+  it('MPPD06 - should successfully parse filters (per_page: 20)', () => {
+    req = { query: { page: '1', per_page: '20', filter: '{"key": "value"}', sort: '{}' } };
 
     const result: MongoPagination = getMongoQuery({}, ctx as ExecutionContext);
 
     expect(result).to.deep.equal({
       filter: { key: 'value' },
-      limit: 0,
+      limit: 20,
       skip: 0,
       sort: {},
       project: {},
@@ -107,7 +107,7 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
     req = {
       query: {
         page: '1',
-        per_page: '0',
+        per_page: '20',
         filter:
           '{"key": "value", "mapreduce": "", "$expr": {"$function": { "body": "function () { return true; }", "args": [], "lang": "js" } } }',
         project: '{"$where": "function () { return true; }"}',
@@ -121,7 +121,7 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
 
     expect(result).to.deep.equal({
       filter: { key: 'value', $expr: {} },
-      limit: 0,
+      limit: 20,
       skip: 0,
       sort: {},
       project: {},
@@ -203,8 +203,8 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
     ).to.throw(BadRequestException);
   });
 
-  it('MPPQD12 - should successfully parse filters (limit: 0) with the query parameter pagination', () => {
-    req = { query: { page: '1', limit: '0', filter: '{"key": "value"}', sort: '{}' } };
+  it('MPPQD12 - should successfully parse filters (limit: 20) with the query parameter pagination', () => {
+    req = { query: { page: '1', limit: '20', filter: '{"key": "value"}', sort: '{}' } };
 
     const defaultLimit = 200;
 
@@ -215,10 +215,22 @@ describe('Unit tests related to the MongoPagination ParamDecorator', () => {
 
     expect(result).to.deep.equal({
       filter: { key: 'value' },
-      limit: 0,
+      limit: 20,
       skip: 0,
       sort: {},
       project: {},
     });
+  });
+
+  it('MPPQD13 - should throw an error when per_page is not a positive number (per_page=-1)', () => {
+    req = { query: { page: '1', per_page: '-1', filter: '{"key": "value"}', sort: '{}' } };
+
+    expect(() => getMongoQuery({}, ctx as ExecutionContext)).to.throw(BadRequestException);
+  });
+
+  it('MPPQD14 - should throw an error when per_page is not a positive number (per_page=0)', () => {
+    req = { query: { page: '1', per_page: '0', filter: '{"key": "value"}', sort: '{}' } };
+
+    expect(() => getMongoQuery({}, ctx as ExecutionContext)).to.throw(BadRequestException);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Throw an error `Bad Request 400` if the limit/per page property is negative or zero.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Currently, if we define the limit (or per page property) as 0 or a negative number, it processes it normally.

However, this can cause some undesired behavior in the service using it:

- Dividing by zero / slicing 0 elements, hence an internal server error;
- Returning the wrong number of elements;

Also, in the link builder, a 0 limit get replaced by the default limit.

https://github.com/algoan/nestjs-components/blob/8031239295428135ca7916f6498c7d72b2eff0af/packages/pagination/src/add-link-header.interceptor.ts#L69

Finally, the 0 case can be understood as an infinite / no limit but this behavior, IMHO, is confusing and contrary with the goal of a pagination (which is to limit and stretch the request and response on both the server and client side).

<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
