### PR TITLE
[FIX] Allow nestjs peer dependencies to be >= 8 and @algoan/pubsub to be >= 4

### DIFF
--- a/packages/google-pubsub-client/package.json
+++ b/packages/google-pubsub-client/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/algoan/nestjs-components/issues"
   },
   "peerDependencies": {
-    "@algoan/pubsub": ">=4.x.x",
+    "@algoan/pubsub": ">=4",
     "@nestjs/common": ">=8",
     "@nestjs/core": ">=8",
     "@nestjs/microservices": ">=8",

--- a/packages/google-pubsub-microservice/package.json
+++ b/packages/google-pubsub-microservice/package.json
@@ -39,9 +39,9 @@
     "url": "https://github.com/algoan/nestjs-components/issues"
   },
   "peerDependencies": {
-    "@algoan/pubsub": ">=4.x.x",
-    "@nestjs/common": ">=8.x.x",
-    "@nestjs/core": ">=8.x.x",
-    "@nestjs/microservices": ">=8.x.x"
+    "@algoan/pubsub": ">=4",
+    "@nestjs/common": ">=8",
+    "@nestjs/core": ">=8",
+    "@nestjs/microservices": ">=8"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Allow nestjs peer dependencies to be >= 8 and @algoan/pubsub to be >= 4 for the packages:

- `google-pubsub-client`
- `google-pubsub-microservices`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This allows to update a nestjs application using those dependencies to be update to v9 or higher. Linked issue: #772

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
