### PR TITLE
[Logging][POC] Add log decorator with ability to mask sensitive fields

### DIFF
--- a/packages/logging-interceptor/src/log.decorator.ts
+++ b/packages/logging-interceptor/src/log.decorator.ts
@@ -1,0 +1,15 @@
+export const METHOD_LOG_METADATA = 'METHOD_LOG_METADATA';
+
+export interface LogOptions {
+  mask?: MethodMask;
+}
+
+export interface MethodMask {
+  request: string[];
+}
+
+export const Log =
+  (options: LogOptions): MethodDecorator =>
+  (_target: Object, _propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>) => {
+    Reflect.defineMetadata(METHOD_LOG_METADATA, options, descriptor.value);
+  };

--- a/packages/logging-interceptor/test/test-app/cats/cats.controller.ts
+++ b/packages/logging-interceptor/test/test-app/cats/cats.controller.ts
@@ -1,4 +1,5 @@
-import { BadRequestException, Controller, Get, InternalServerErrorException } from '@nestjs/common';
+import { BadRequestException, Controller, Get, InternalServerErrorException, Param, Post, Put } from '@nestjs/common';
+import { Log } from '../../../src/log.decorator';
 
 /**
  * Controller: /cats
@@ -25,5 +26,23 @@ export class CatsController {
   @Get('internalerror')
   public internalerror(): string {
     throw new InternalServerErrorException();
+  }
+
+  /**
+   * Update a cat by id
+   */
+  @Put('/:catId')
+  @Log({ mask: { request: ['password', 'interests', 'address.country', 'address.city', 'payments.bank.name'] } })
+  public getCatById(@Param('catId') catId: string) {
+    return `This action returns a cat(id: ${catId}) from the cats' list`;
+  }
+
+  /**
+   * Login
+   */
+  @Post('login')
+  @Log({ mask: { request: ['password'] } })
+  public login() {
+    return 'This action login with a cat credential';
   }
 }


### PR DESCRIPTION
## Description

This POC is inspired from this proposition: https://github.com/algoan/nestjs-components/pull/675
Comparing to the initial proposition, the fields to mask are not provided when the logging interceptor is built but at the method level, thanks to a Log decorator. The decorator can be used like this:

```ts
  @Get('/:accountId')
  @Log({ mask: { request: ['iban', 'payments.bank.name'] } })
  public getAccountById(@Param('accountId') accountId: string) {
    return `This action returns an account with the id ${accountId}`;
  }
```

In my opinion, doing so improves the developer experience of the feature and simplify the implementation. By the way, I decided to create a generic log decorator so that we can give more logging options later on.



If this POC is validated, we will have to allow response masking.

## Motivation and Context
Currently, the logging interceptor logs the whole body of the request and of the response. However, they can contain sensitive data which should be not logged. So you give the ability to mask some fields for each request.

Fix #611 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
