### PR TITLE
[Logging] Add log decorator with ability to mask sensitive fields

### DIFF
--- a/packages/logging-interceptor/README.md
+++ b/packages/logging-interceptor/README.md
@@ -60,12 +60,7 @@ import { LoggingInterceptor } from '@algoan/nestjs-logging-interceptor';
   providers: [
     {
       provide: APP_INTERCEPTOR,
-      useFactory: () => {
-        const interceptor: LoggingInterceptor = new LoggingInterceptor();
-        interceptor.setUserPrefix('ExampleApp');
-
-        return interceptor;
-      },
+      useFactory: () => new LoggingInterceptor({ userPrefix: 'ExampleApp'}),
     },
   ],
 })
@@ -233,13 +228,11 @@ import { LoggingInterceptor } from '@algoan/nestjs-logging-interceptor';
   providers: [
     {
       provide: APP_INTERCEPTOR,
-      useFactory: () => {
-        const interceptor: LoggingInterceptor = new LoggingInterceptor();
-        interceptor.setDisabledMasking(true); // Ignore masking options in the entire applications
-        interceptor.setMaskingPlaceholder("hidden"); // Replace the default placeholder '****' by a custom one
-
-        return interceptor;
-      },
+      useFactory: () =>
+        new LoggingInterceptor({
+          disableMasking: true, // Ignore masking options in the entire applications
+          maskingPlaceholder: 'hidden', // Replace the default placeholder '****' by a custom one
+        }),
     },
   ],
 })

--- a/packages/logging-interceptor/README.md
+++ b/packages/logging-interceptor/README.md
@@ -60,7 +60,7 @@ import { LoggingInterceptor } from '@algoan/nestjs-logging-interceptor';
   providers: [
     {
       provide: APP_INTERCEPTOR,
-      useClass: () => {
+      useFactory: () => {
         const interceptor: LoggingInterceptor = new LoggingInterceptor();
         interceptor.setUserPrefix('ExampleApp');
 
@@ -233,7 +233,7 @@ import { LoggingInterceptor } from '@algoan/nestjs-logging-interceptor';
   providers: [
     {
       provide: APP_INTERCEPTOR,
-      useClass: () => {
+      useFactory: () => {
         const interceptor: LoggingInterceptor = new LoggingInterceptor();
         interceptor.setDisabledMasking(true); // Ignore masking options in the entire applications
         interceptor.setMaskingPlaceholder("hidden"); // Replace the default placeholder '****' by a custom one

--- a/packages/logging-interceptor/README.md
+++ b/packages/logging-interceptor/README.md
@@ -222,7 +222,7 @@ The body in the logged request will be:
 
 If you want you to mask the whole body of the request/response, you can pass `true` instead of the array containing the exhaustive list of properties.
 
-In addition, if you want to ignore masking options in the entire application, you can disable the feature at the interceptor level:
+In addition, other options can be set at the interceptor level:
 
 ```typescript
 import { Module } from '@nestjs/common';
@@ -235,7 +235,8 @@ import { LoggingInterceptor } from '@algoan/nestjs-logging-interceptor';
       provide: APP_INTERCEPTOR,
       useClass: () => {
         const interceptor: LoggingInterceptor = new LoggingInterceptor();
-        interceptor.setDisabledMasking(true);
+        interceptor.setDisabledMasking(true); // Ignore masking options in the entire applications
+        interceptor.setMaskingPlaceholder("hidden"); // Replace the default placeholder '****' by a custom one
 
         return interceptor;
       },

--- a/packages/logging-interceptor/README.md
+++ b/packages/logging-interceptor/README.md
@@ -83,6 +83,7 @@ The context message will be preprend by the provided `userPrefix`:
 
 This interceptor logs:
   - incoming request details
+  - outgoing response details
 
 ### Default Logger messages
 ```bash

--- a/packages/logging-interceptor/src/index.ts
+++ b/packages/logging-interceptor/src/index.ts
@@ -1,1 +1,2 @@
+export * from './log.decorator';
 export * from './logging.interceptor';

--- a/packages/logging-interceptor/src/log.decorator.ts
+++ b/packages/logging-interceptor/src/log.decorator.ts
@@ -1,3 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+
 export const METHOD_LOG_METADATA: string = 'METHOD_LOG_METADATA';
 
 /**
@@ -32,9 +34,4 @@ export interface MaskingOptions {
  * Log decorator. It allows to customise logging behaviour for each route.
  * @param options the logging options
  */
-export const Log =
-  (options: LogOptions): MethodDecorator =>
-  // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
-  (_target: Object, _propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>) => {
-    Reflect.defineMetadata(METHOD_LOG_METADATA, options, descriptor.value);
-  };
+export const Log = (options: LogOptions) => SetMetadata(METHOD_LOG_METADATA, options);

--- a/packages/logging-interceptor/src/log.decorator.ts
+++ b/packages/logging-interceptor/src/log.decorator.ts
@@ -1,0 +1,40 @@
+export const METHOD_LOG_METADATA: string = 'METHOD_LOG_METADATA';
+
+/**
+ * Log options
+ */
+export interface LogOptions {
+  /**
+   * Masking options
+   */
+  mask?: MaskingOptions;
+}
+
+/**
+ * Masking options
+ */
+export interface MaskingOptions {
+  /**
+   * Mask of the request body. It can be a boolean or an array of strings.
+   * If it is true, it will mask all the body.
+   * If it is an array of strings, it will mask only the specified fields.
+   */
+  request?: string[] | boolean;
+  /**
+   * Mask of the response body. It can be a boolean or an array of strings.
+   * If it is true, it will mask all the body.
+   * If it is an array of strings, it will mask only the specified fields.
+   */
+  response?: string[] | boolean;
+}
+
+/**
+ * Log decorator. It allows to customise logging behaviour for each route.
+ * @param options the logging options
+ */
+export const Log =
+  (options: LogOptions): MethodDecorator =>
+  // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
+  (_target: Object, _propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>) => {
+    Reflect.defineMetadata(METHOD_LOG_METADATA, options, descriptor.value);
+  };

--- a/packages/logging-interceptor/src/logging.interceptor.ts
+++ b/packages/logging-interceptor/src/logging.interceptor.ts
@@ -19,9 +19,15 @@ import { LogOptions, METHOD_LOG_METADATA } from './log.decorator';
 export class LoggingInterceptor implements NestInterceptor {
   private readonly ctxPrefix: string = LoggingInterceptor.name;
   private readonly logger: Logger = new Logger(this.ctxPrefix);
-  private userPrefix: string = '';
-  private disableMasking: boolean = false;
-  private maskingPlaceholder: string | undefined = '****';
+  private userPrefix: string;
+  private disableMasking: boolean;
+  private maskingPlaceholder: string | undefined;
+
+  constructor(options?: { userPrefix?: string; disableMasking?: boolean; maskingPlaceholder?: string }) {
+    this.userPrefix = options?.userPrefix ?? '';
+    this.disableMasking = options?.disableMasking ?? false;
+    this.maskingPlaceholder = options?.maskingPlaceholder ?? '****';
+  }
 
   /**
    * User prefix setter

--- a/packages/logging-interceptor/src/logging.interceptor.ts
+++ b/packages/logging-interceptor/src/logging.interceptor.ts
@@ -6,6 +6,7 @@ import {
   Injectable,
   Logger,
   NestInterceptor,
+  Optional,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { Observable } from 'rxjs';
@@ -23,7 +24,7 @@ export class LoggingInterceptor implements NestInterceptor {
   private disableMasking: boolean;
   private maskingPlaceholder: string | undefined;
 
-  constructor(options?: { userPrefix?: string; disableMasking?: boolean; maskingPlaceholder?: string }) {
+  constructor(@Optional() options?: { userPrefix?: string; disableMasking?: boolean; maskingPlaceholder?: string }) {
     this.userPrefix = options?.userPrefix ?? '';
     this.disableMasking = options?.disableMasking ?? false;
     this.maskingPlaceholder = options?.maskingPlaceholder ?? '****';

--- a/packages/logging-interceptor/src/logging.interceptor.ts
+++ b/packages/logging-interceptor/src/logging.interceptor.ts
@@ -21,7 +21,7 @@ export class LoggingInterceptor implements NestInterceptor {
   private readonly logger: Logger = new Logger(this.ctxPrefix);
   private userPrefix: string = '';
   private disableMasking: boolean = false;
-  private readonly MASK_MARKER: string = '****';
+  private maskingPlaceholder: string | undefined = '****';
 
   /**
    * User prefix setter
@@ -37,6 +37,14 @@ export class LoggingInterceptor implements NestInterceptor {
    */
   public setDisableMasking(disableMasking: boolean): void {
     this.disableMasking = disableMasking;
+  }
+
+  /**
+   * Set the masking placeholder
+   * @param placeholder
+   */
+  public setMaskingPlaceholder(placeholder: string | undefined): void {
+    this.maskingPlaceholder = placeholder;
   }
   /**
    * Intercept method, logs before and after the request being processed
@@ -163,7 +171,7 @@ export class LoggingInterceptor implements NestInterceptor {
     }
 
     if (maskingOptions === true || maskingOptions.includes(path)) {
-      return this.MASK_MARKER;
+      return this.maskingPlaceholder;
     }
 
     if (Array.isArray(data)) {

--- a/packages/logging-interceptor/src/logging.interceptor.ts
+++ b/packages/logging-interceptor/src/logging.interceptor.ts
@@ -20,6 +20,7 @@ export class LoggingInterceptor implements NestInterceptor {
   private readonly ctxPrefix: string = LoggingInterceptor.name;
   private readonly logger: Logger = new Logger(this.ctxPrefix);
   private userPrefix: string = '';
+  private disableMasking: boolean = false;
   private readonly MASK_MARKER: string = '****';
 
   /**
@@ -30,6 +31,13 @@ export class LoggingInterceptor implements NestInterceptor {
     this.userPrefix = `${prefix} - `;
   }
 
+  /**
+   * Set the disable masking flag
+   * @param disableMasking
+   */
+  public setDisableMasking(disableMasking: boolean): void {
+    this.disableMasking = disableMasking;
+  }
   /**
    * Intercept method, logs before and after the request being processed
    * @param context details about the current request
@@ -150,6 +158,10 @@ export class LoggingInterceptor implements NestInterceptor {
    * @returns the masked data
    */
   private maskData(data: unknown, maskingOptions: string[] | true, path: string = ''): unknown {
+    if (this.disableMasking) {
+      return data;
+    }
+
     if (maskingOptions === true || maskingOptions.includes(path)) {
       return this.MASK_MARKER;
     }

--- a/packages/logging-interceptor/test/logging.interceptor.test.ts
+++ b/packages/logging-interceptor/test/logging.interceptor.test.ts
@@ -32,121 +32,123 @@ describe('Logging interceptor', () => {
     jest.clearAllMocks();
   });
 
-  it('logs the input and output request details - OK status code', async () => {
-    const logSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'log');
-    const url: string = `/cats/ok`;
+  describe('Default behaviour', () => {
+    it('logs the input and output request details - OK status code', async () => {
+      const logSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'log');
+      const url: string = `/cats/ok`;
 
-    await request(app.getHttpServer()).get(url).expect(HttpStatus.OK);
+      await request(app.getHttpServer()).get(url).expect(HttpStatus.OK);
 
-    const ctx: string = `LoggingInterceptor - GET - ${url}`;
-    const resCtx: string = `LoggingInterceptor - 200 - GET - ${url}`;
-    const incomingMsg: string = `Incoming request - GET - ${url}`;
-    const outgoingMsg: string = `Outgoing response - 200 - GET - ${url}`;
+      const ctx: string = `LoggingInterceptor - GET - ${url}`;
+      const resCtx: string = `LoggingInterceptor - 200 - GET - ${url}`;
+      const incomingMsg: string = `Incoming request - GET - ${url}`;
+      const outgoingMsg: string = `Outgoing response - 200 - GET - ${url}`;
 
-    /**
-     * Info level
-     */
-    expect(logSpy).toBeCalledTimes(2);
-    expect(logSpy.mock.calls[0]).toEqual([
-      {
-        body: {},
-        headers: expect.any(Object),
-        message: incomingMsg,
-        method: `GET`,
-      },
-      ctx,
-    ]);
-    expect(logSpy.mock.calls[1]).toEqual([
-      {
-        message: outgoingMsg,
-        body: `This action returns all cats`,
-      },
-      resCtx,
-    ]);
-  });
+      /**
+       * Info level
+       */
+      expect(logSpy).toBeCalledTimes(2);
+      expect(logSpy.mock.calls[0]).toEqual([
+        {
+          body: {},
+          headers: expect.any(Object),
+          message: incomingMsg,
+          method: `GET`,
+        },
+        ctx,
+      ]);
+      expect(logSpy.mock.calls[1]).toEqual([
+        {
+          message: outgoingMsg,
+          body: `This action returns all cats`,
+        },
+        resCtx,
+      ]);
+    });
 
-  it('logs the input and output request details - BAD_REQUEST status code', async () => {
-    const logSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'log');
-    const warnSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'warn');
-    const errorSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'error');
-    const url: string = `/cats/badrequest`;
+    it('logs the input and output request details - BAD_REQUEST status code', async () => {
+      const logSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'log');
+      const warnSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'warn');
+      const errorSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'error');
+      const url: string = `/cats/badrequest`;
 
-    await request(app.getHttpServer()).get(url).expect(HttpStatus.BAD_REQUEST);
+      await request(app.getHttpServer()).get(url).expect(HttpStatus.BAD_REQUEST);
 
-    const ctx: string = `LoggingInterceptor - GET - ${url}`;
-    const resCtx: string = `LoggingInterceptor - 400 - GET - ${url}`;
-    const incomingMsg: string = `Incoming request - GET - ${url}`;
-    const outgoingMsg: string = `Outgoing response - 400 - GET - ${url}`;
+      const ctx: string = `LoggingInterceptor - GET - ${url}`;
+      const resCtx: string = `LoggingInterceptor - 400 - GET - ${url}`;
+      const incomingMsg: string = `Incoming request - GET - ${url}`;
+      const outgoingMsg: string = `Outgoing response - 400 - GET - ${url}`;
 
-    /**
-     * Info level
-     */
-    expect(logSpy).toBeCalledTimes(1);
-    expect(logSpy.mock.calls[0]).toEqual([
-      {
-        body: {},
-        headers: expect.any(Object),
-        message: incomingMsg,
-        method: `GET`,
-      },
-      ctx,
-    ]);
+      /**
+       * Info level
+       */
+      expect(logSpy).toBeCalledTimes(1);
+      expect(logSpy.mock.calls[0]).toEqual([
+        {
+          body: {},
+          headers: expect.any(Object),
+          message: incomingMsg,
+          method: `GET`,
+        },
+        ctx,
+      ]);
 
-    expect(warnSpy).toBeCalledTimes(1);
-    expect(warnSpy.mock.calls[0]).toEqual([
-      {
-        message: outgoingMsg,
-        method: 'GET',
-        url: '/cats/badrequest',
-        body: {},
-        error: expect.any(BadRequestException),
-      },
-      resCtx,
-    ]);
+      expect(warnSpy).toBeCalledTimes(1);
+      expect(warnSpy.mock.calls[0]).toEqual([
+        {
+          message: outgoingMsg,
+          method: 'GET',
+          url: '/cats/badrequest',
+          body: {},
+          error: expect.any(BadRequestException),
+        },
+        resCtx,
+      ]);
 
-    expect(errorSpy).not.toHaveBeenCalled();
-  });
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
 
-  it('logs the input and output request details - INTERNAL_SERVER_ERROR status code', async () => {
-    const logSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'log');
-    const warnSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'warn');
-    const errorSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'error');
-    const url: string = '/cats/internalerror';
+    it('logs the input and output request details - INTERNAL_SERVER_ERROR status code', async () => {
+      const logSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'log');
+      const warnSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'warn');
+      const errorSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'error');
+      const url: string = '/cats/internalerror';
 
-    await request(app.getHttpServer()).get(url).expect(HttpStatus.INTERNAL_SERVER_ERROR);
+      await request(app.getHttpServer()).get(url).expect(HttpStatus.INTERNAL_SERVER_ERROR);
 
-    const ctx: string = `LoggingInterceptor - GET - ${url}`;
-    const resCtx: string = `LoggingInterceptor - 500 - GET - ${url}`;
-    const incomingMsg: string = `Incoming request - GET - ${url}`;
-    const outgoingMsg: string = `Outgoing response - 500 - GET - ${url}`;
+      const ctx: string = `LoggingInterceptor - GET - ${url}`;
+      const resCtx: string = `LoggingInterceptor - 500 - GET - ${url}`;
+      const incomingMsg: string = `Incoming request - GET - ${url}`;
+      const outgoingMsg: string = `Outgoing response - 500 - GET - ${url}`;
 
-    /**
-     * Info level
-     */
-    expect(logSpy).toBeCalledTimes(1);
-    expect(logSpy.mock.calls[0]).toEqual([
-      {
-        body: {},
-        headers: expect.any(Object),
-        message: incomingMsg,
-        method: `GET`,
-      },
-      ctx,
-    ]);
+      /**
+       * Info level
+       */
+      expect(logSpy).toBeCalledTimes(1);
+      expect(logSpy.mock.calls[0]).toEqual([
+        {
+          body: {},
+          headers: expect.any(Object),
+          message: incomingMsg,
+          method: `GET`,
+        },
+        ctx,
+      ]);
 
-    expect(errorSpy).toBeCalledTimes(1);
-    expect(errorSpy.mock.calls[0]).toEqual([
-      {
-        message: outgoingMsg,
-        method: 'GET',
-        url: '/cats/internalerror',
-        body: {},
-        error: expect.any(InternalServerErrorException),
-      },
-      expect.any(String),
-      resCtx,
-    ]);
+      expect(errorSpy).toBeCalledTimes(1);
+      expect(errorSpy.mock.calls[0]).toEqual([
+        {
+          message: outgoingMsg,
+          method: 'GET',
+          url: '/cats/internalerror',
+          body: {},
+          error: expect.any(InternalServerErrorException),
+        },
+        expect.any(String),
+        resCtx,
+      ]);
 
-    expect(warnSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/logging-interceptor/test/test-app/cats/cats.controller.ts
+++ b/packages/logging-interceptor/test/test-app/cats/cats.controller.ts
@@ -1,4 +1,7 @@
-import { BadRequestException, Controller, Get, InternalServerErrorException } from '@nestjs/common';
+/* eslint-disable */
+import { BadRequestException, Body, Controller, Get, InternalServerErrorException, Param, Post } from '@nestjs/common';
+import { Log } from '../../../src';
+import { CreateCatDto } from './create-cat.dto';
 
 /**
  * Controller: /cats
@@ -25,5 +28,52 @@ export class CatsController {
   @Get('internalerror')
   public internalerror(): string {
     throw new InternalServerErrorException();
+  }
+
+  /**
+   * Create a cat
+   */
+  @Post()
+  @Log({
+    mask: {
+      request: ['birthdate', 'interests.description', 'address', 'enemies'],
+      response: ['id', 'birthdate', 'interests.description', 'address', 'enemies'],
+    },
+  })
+  public createCat(@Body() payload: CreateCatDto) {
+    return { id: 1, ...payload };
+  }
+
+  @Get()
+  @Log({
+    mask: {
+      response: ['interests.description', 'unknownProperty'],
+    },
+  })
+  public getCats() {
+    return [
+      {
+        id: 1,
+        name: 'Tom',
+        interests: [
+          { description: 'Eating Jerry', level: 'HIGH' },
+          { description: 'Sleeping', level: 'MEDIUM' },
+        ],
+      },
+      {
+        id: 2,
+        name: 'Sylvestre',
+        interests: [{ description: 'Eating Titi', level: 'HIGH' }],
+      },
+    ];
+  }
+
+  /**
+   * Create a password for a cat
+   */
+  @Post(':id/password')
+  @Log({ mask: { request: true, response: true } })
+  public createPassword(@Param('id') id: string, @Body() payload: { password: string }) {
+    return `The password for cat ${id} is ${payload.password}`;
   }
 }

--- a/packages/logging-interceptor/test/test-app/cats/create-cat.dto.ts
+++ b/packages/logging-interceptor/test/test-app/cats/create-cat.dto.ts
@@ -1,0 +1,10 @@
+/**
+ * Dto to create a new cat
+ */
+export interface CreateCatDto {
+  name: string;
+  birthdate?: string;
+  address?: { country: string; city: string };
+  enemies?: string[];
+  interests?: { description: string; level: 'HIGH' | 'MEDIUM' | 'LOW' }[];
+}


### PR DESCRIPTION
## Description

This PR is inspired from this proposition: https://github.com/algoan/nestjs-components/pull/675
Comparing to the initial proposition, the fields to mask are not provided when the logging interceptor is built but at the method level, thanks to a Log decorator. The decorator can be used like this:

```ts
  @Get('/:accountId')
  @Log({ mask: { request: ['iban', 'payments.bank.name'] } })
  public getAccountById(@Param('accountId') accountId: string) {
    return `This action returns an account with the id ${accountId}`;
  }
```

In my opinion, doing so improves the developer experience of the feature and simplify the implementation. By the way, I decided to create a generic log decorator so that we can give more logging options later on.

Please, take a look at the updated README to get details about masking options.

## Motivation and Context
Currently, the logging interceptor logs the whole body of the request and of the response. However, they can contain sensitive data which should be not logged. So you give the ability to mask some fields for each request.

Fix #611 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
