### PR TITLE
fix: parse the data to json before masking the properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "@algoan/nestjs-google-pubsub-microservice": "file:packages/google-pubsub-microservice",
         "@algoan/nestjs-http-exception-filter": "file:packages/http-exception-filter",
         "@algoan/nestjs-logging-interceptor": "file:packages/logging-interceptor",
-        "@algoan/nestjs-pagination": "file:packages/pagination"
+        "@algoan/nestjs-pagination": "file:packages/pagination",
+        "flatted": "^3.2.9"
       },
       "devDependencies": {
         "@algoan/eslint-config": "^2.0.1",
@@ -8550,8 +8551,7 @@
     "node_modules/flatted": {
       "version": "3.2.9",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
-      "dev": true
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.3",
@@ -25489,8 +25489,7 @@
     "flatted": {
       "version": "3.2.9",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
-      "dev": true
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
     "follow-redirects": {
       "version": "1.15.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19105,6 +19105,9 @@
       "name": "@algoan/nestjs-logging-interceptor",
       "version": "2.2.0",
       "license": "ISC",
+      "dependencies": {
+        "flatted": "^3.2.9"
+      },
       "peerDependencies": {
         "@nestjs/common": ">=5",
         "@nestjs/core": ">=5",
@@ -19177,7 +19180,9 @@
     },
     "@algoan/nestjs-logging-interceptor": {
       "version": "file:packages/logging-interceptor",
-      "requires": {}
+      "requires": {
+        "flatted": "^3.2.9"
+      }
     },
     "@algoan/nestjs-pagination": {
       "version": "file:packages/pagination",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@algoan/nestjs-google-pubsub-microservice": "file:packages/google-pubsub-microservice",
     "@algoan/nestjs-http-exception-filter": "file:packages/http-exception-filter",
     "@algoan/nestjs-logging-interceptor": "file:packages/logging-interceptor",
-    "@algoan/nestjs-pagination": "file:packages/pagination"
+    "@algoan/nestjs-pagination": "file:packages/pagination",
+    "flatted": "^3.2.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "@algoan/nestjs-google-pubsub-microservice": "file:packages/google-pubsub-microservice",
     "@algoan/nestjs-http-exception-filter": "file:packages/http-exception-filter",
     "@algoan/nestjs-logging-interceptor": "file:packages/logging-interceptor",
-    "@algoan/nestjs-pagination": "file:packages/pagination",
-    "flatted": "^3.2.9"
+    "@algoan/nestjs-pagination": "file:packages/pagination"
   }
 }

--- a/packages/logging-interceptor/package.json
+++ b/packages/logging-interceptor/package.json
@@ -37,5 +37,8 @@
     "@nestjs/core": ">=5",
     "express": ">=4",
     "rxjs": ">=6"
+  },
+  "dependencies": {
+    "flatted": "^3.2.9"
   }
 }

--- a/packages/logging-interceptor/src/logging.interceptor.ts
+++ b/packages/logging-interceptor/src/logging.interceptor.ts
@@ -173,31 +173,33 @@ export class LoggingInterceptor implements NestInterceptor {
    * @returns the masked data
    */
   private maskData(data: unknown, maskingOptions: string[] | true, path: string = ''): unknown {
+    const dataToMask = JSON.parse(JSON.stringify(data));
+
     if (this.disableMasking) {
-      return data;
+      return dataToMask;
     }
 
     if (maskingOptions === true || maskingOptions.includes(path)) {
       return this.maskingPlaceholder;
     }
 
-    if (Array.isArray(data)) {
-      return data.map((item: unknown): unknown => this.maskData(item, maskingOptions, path));
+    if (Array.isArray(dataToMask)) {
+      return dataToMask.map((item: unknown): unknown => this.maskData(item, maskingOptions, path));
     }
 
     // eslint-disable-next-line no-null/no-null
-    if (typeof data === 'object' && data !== null) {
-      return Object.keys(data).reduce<object>((maskedObject: object, key: string): object => {
+    if (typeof dataToMask === 'object' && dataToMask !== null) {
+      return Object.keys(dataToMask).reduce<object>((maskedObject: object, key: string): object => {
         const nestedPath = path ? `${path}.${key}` : key;
 
         return {
           ...maskedObject,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          [key]: this.maskData((data as any)[key], maskingOptions, nestedPath),
+          [key]: this.maskData((dataToMask as any)[key], maskingOptions, nestedPath),
         };
       }, {});
     }
 
-    return data;
+    return dataToMask;
   }
 }

--- a/packages/logging-interceptor/src/logging.interceptor.ts
+++ b/packages/logging-interceptor/src/logging.interceptor.ts
@@ -11,6 +11,8 @@ import {
 import { Request, Response } from 'express';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { parse, stringify } from 'flatted';
 import { LogOptions, METHOD_LOG_METADATA } from './log.decorator';
 
 /**
@@ -173,8 +175,8 @@ export class LoggingInterceptor implements NestInterceptor {
    * @returns the masked data
    */
   private maskData(data: unknown, maskingOptions: string[] | true, path: string = ''): unknown {
-    // Parse the data to avoid having constructors like new ObjectId() in the body
-    const parsedData = JSON.parse(JSON.stringify(data));
+    // Parse the data to avoid having constructors like new ObjectId() in the body and handle circular references
+    const parsedData = parse(stringify(data));
 
     if (this.disableMasking) {
       return parsedData;

--- a/packages/logging-interceptor/src/logging.interceptor.ts
+++ b/packages/logging-interceptor/src/logging.interceptor.ts
@@ -11,7 +11,6 @@ import {
 import { Request, Response } from 'express';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { parse, stringify } from 'flatted';
 import { LogOptions, METHOD_LOG_METADATA } from './log.decorator';
 

--- a/packages/logging-interceptor/src/logging.interceptor.ts
+++ b/packages/logging-interceptor/src/logging.interceptor.ts
@@ -173,6 +173,7 @@ export class LoggingInterceptor implements NestInterceptor {
    * @returns the masked data
    */
   private maskData(data: unknown, maskingOptions: string[] | true, path: string = ''): unknown {
+    // Parse the data to avoid having constructors like new ObjectId() in the body
     const dataToMask = JSON.parse(JSON.stringify(data));
 
     if (this.disableMasking) {

--- a/packages/logging-interceptor/src/logging.interceptor.ts
+++ b/packages/logging-interceptor/src/logging.interceptor.ts
@@ -174,33 +174,33 @@ export class LoggingInterceptor implements NestInterceptor {
    */
   private maskData(data: unknown, maskingOptions: string[] | true, path: string = ''): unknown {
     // Parse the data to avoid having constructors like new ObjectId() in the body
-    const dataToMask = JSON.parse(JSON.stringify(data));
+    const parsedData = JSON.parse(JSON.stringify(data));
 
     if (this.disableMasking) {
-      return dataToMask;
+      return parsedData;
     }
 
     if (maskingOptions === true || maskingOptions.includes(path)) {
       return this.maskingPlaceholder;
     }
 
-    if (Array.isArray(dataToMask)) {
-      return dataToMask.map((item: unknown): unknown => this.maskData(item, maskingOptions, path));
+    if (Array.isArray(parsedData)) {
+      return parsedData.map((item: unknown): unknown => this.maskData(item, maskingOptions, path));
     }
 
     // eslint-disable-next-line no-null/no-null
-    if (typeof dataToMask === 'object' && dataToMask !== null) {
-      return Object.keys(dataToMask).reduce<object>((maskedObject: object, key: string): object => {
+    if (typeof parsedData === 'object' && parsedData !== null) {
+      return Object.keys(parsedData).reduce<object>((maskedObject: object, key: string): object => {
         const nestedPath = path ? `${path}.${key}` : key;
 
         return {
           ...maskedObject,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          [key]: this.maskData((dataToMask as any)[key], maskingOptions, nestedPath),
+          [key]: this.maskData((parsedData as any)[key], maskingOptions, nestedPath),
         };
       }, {});
     }
 
-    return dataToMask;
+    return parsedData;
   }
 }


### PR DESCRIPTION
## Description

Through this PR we parsed the body of the data to anonymise in the `maskData` data function to make sure that the recursive function is called on a formatted body without constructors like `new ObjectId()`
