### PR TITLE
[FEAT] apply log masks to http exception body

### DIFF
--- a/packages/logging-interceptor/src/logging.interceptor.ts
+++ b/packages/logging-interceptor/src/logging.interceptor.ts
@@ -131,12 +131,17 @@ export class LoggingInterceptor implements NestInterceptor {
       const ctx: string = `${this.userPrefix}${this.ctxPrefix} - ${statusCode} - ${method} - ${url}`;
       const message: string = `Outgoing response - ${statusCode} - ${method} - ${url}`;
 
+      const options: LogOptions | undefined = Reflect.getMetadata(METHOD_LOG_METADATA, context.getHandler());
+
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      const maskedBody = options?.mask?.request ? this.maskData(body, options.mask.request) : body;
+
       if (statusCode >= HttpStatus.INTERNAL_SERVER_ERROR) {
         this.logger.error(
           {
             method,
             url,
-            body,
+            body: maskedBody,
             message,
             error,
           },
@@ -149,7 +154,7 @@ export class LoggingInterceptor implements NestInterceptor {
             method,
             url,
             error,
-            body,
+            body: maskedBody,
             message,
           },
           ctx,

--- a/packages/logging-interceptor/test/logging.interceptor.test.ts
+++ b/packages/logging-interceptor/test/logging.interceptor.test.ts
@@ -366,5 +366,35 @@ describe('Logging interceptor', () => {
 
       interceptor.setMaskingPlaceholder(placeholder);
     });
+
+    it('should mask http exception response', async () => {
+      const logSpy: jest.SpyInstance = jest.spyOn(Logger.prototype, 'log');
+      const url: string = `/cats`;
+
+      await request(app.getHttpServer())
+        .post(url)
+        .send({
+          name: 'dog',
+          birthdate: '1980-01-01',
+        })
+        .expect(HttpStatus.BAD_REQUEST);
+
+      const ctx: string = `LoggingInterceptor - POST - ${url}`;
+      const incomingMsg: string = `Incoming request - POST - ${url}`;
+
+      expect(logSpy).toBeCalledTimes(1);
+      expect(logSpy.mock.calls[0]).toEqual([
+        {
+          body: {
+            name: 'dog',
+            birthdate: placeholder,
+          },
+          headers: expect.any(Object),
+          message: incomingMsg,
+          method: `POST`,
+        },
+        ctx,
+      ]);
+    });
   });
 });

--- a/packages/logging-interceptor/test/test-app/cats/cats.controller.ts
+++ b/packages/logging-interceptor/test/test-app/cats/cats.controller.ts
@@ -41,6 +41,10 @@ export class CatsController {
     },
   })
   public createCat(@Body() payload: CreateCatDto) {
+    if (payload.name === 'dog') {
+      throw new BadRequestException({ message: 'You cannot name a cat dog' });
+    }
+
     return { id: 1, ...payload };
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request aims to apply log masks to HTTP exception body.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For HTTP exceptions, the request body is displayed in the logs (error or warn). Thus the masking options should be applied to the body. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
