### PR TITLE
[CI] Fix token used during both publish

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -68,10 +68,21 @@ jobs:
       name: Run Lerna version
       env:
         GH_TOKEN: ${{ secrets.PUBLIC_REPO_GHA_PAT }}
+    - name: Setting NPM configs to publish to NPM
+      run: |
+        echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" > .npmrc
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - name: Publishing to NPM
       run: npx lerna publish from-git --yes --registry=https://registry.npmjs.org
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: Setting NPM configs to publish to GitHub Packages
+      run: |
+        echo "@algoan:registry=https://npm.pkg.github.com" > .npmrc
+        echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" >> .npmrc
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.PUBLIC_REPO_GHA_PAT }}
     - name: Publishing to GitHub Packages
       run: npx lerna publish from-git --yes --registry=https://npm.pkg.github.com
       env:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix token used during both publish on NPM and GitHub Packages.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

My previous PR #821 to add dual publish didn't work as expected.

It actually does not publish to NPM anymore. I infer this is because the NODE_AUTH_TOKEN is not uses correctly by lerna during the publish.

To fix that, we define the token and registry to use in the `.npmrc` file.

This was the method used to publish only on NPM.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
