### PR TITLE
[CI] Fix token use during github packages publish

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -82,8 +82,8 @@ jobs:
         echo "@algoan:registry=https://npm.pkg.github.com" > .npmrc
         echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" >> .npmrc
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.PUBLIC_REPO_GHA_PAT }}
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publishing to GitHub Packages
       run: npx lerna publish from-git --yes --registry=https://npm.pkg.github.com
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.PUBLIC_REPO_GHA_PAT }}
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix token use during github packages publish

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Current token returns the following error during publish:

```
lerna WARN notice Package failed to publish: @algoan/nestjs-custom-decorators
lerna ERR! E403 Permission permission_denied: The token provided does not match expected scopes.
lerna ERR! errno "undefined" is not a valid exit code - exiting with code 1
Error: Process completed with exit code 1.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
