### PR TITLE
[CLASS_TRANSFORMERS] Extends class-transform package with EnumFallback decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ A package containing overriden class validators.
 
 See [the documentation here](./packages/class-validators).
 
+## NestJS class transformers
+
+A package containing custom class transformers.
+
+See [the documentation here](./packages/class-transformers).
+
 # Contribution
 
 This repository is managed by [Lerna.js](https://lerna.js.org). If you want to contribute, you need to follow these instructions:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@algoan/nestjs-class-transformers": "file:packages/class-transformers",
         "@algoan/nestjs-class-validators": "file:packages/class-validators",
         "@algoan/nestjs-custom-decorators": "file:packages/custom-decorators",
         "@algoan/nestjs-google-pubsub-client": "file:packages/google-pubsub-client",
@@ -97,6 +98,10 @@
         "prettier": ">= 2",
         "typescript": ">= 3"
       }
+    },
+    "node_modules/@algoan/nestjs-class-transformers": {
+      "resolved": "packages/class-transformers",
+      "link": true
     },
     "node_modules/@algoan/nestjs-class-validators": {
       "resolved": "packages/class-validators",
@@ -6102,8 +6107,7 @@
     "node_modules/class-transformer": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
-      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "devOptional": true
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "node_modules/class-validator": {
       "version": "0.14.0",
@@ -19092,6 +19096,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/class-transformers": {
+      "name": "@algoan/nestjs-class-transformers",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "class-transformer": "^0.5.1"
+      }
+    },
     "packages/class-validators": {
       "name": "@algoan/nestjs-class-validators",
       "version": "0.0.2",
@@ -19208,6 +19220,12 @@
         "eslint-plugin-jsdoc": "^46.8.2",
         "eslint-plugin-no-null": "^1.0.2",
         "eslint-plugin-prefer-arrow": "^1.2.3"
+      }
+    },
+    "@algoan/nestjs-class-transformers": {
+      "version": "file:packages/class-transformers",
+      "requires": {
+        "class-transformer": "^0.5.1"
       }
     },
     "@algoan/nestjs-class-validators": {
@@ -23696,8 +23714,7 @@
     "class-transformer": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
-      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "devOptional": true
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "class-validator": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     }
   },
   "dependencies": {
+    "@algoan/nestjs-class-transformers": "file:packages/class-transformers",
     "@algoan/nestjs-class-validators": "file:packages/class-validators",
     "@algoan/nestjs-custom-decorators": "file:packages/custom-decorators",
     "@algoan/nestjs-google-pubsub-client": "file:packages/google-pubsub-client",

--- a/package.json
+++ b/package.json
@@ -89,12 +89,12 @@
     }
   },
   "dependencies": {
+    "@algoan/nestjs-class-validators": "file:packages/class-validators",
     "@algoan/nestjs-custom-decorators": "file:packages/custom-decorators",
     "@algoan/nestjs-google-pubsub-client": "file:packages/google-pubsub-client",
     "@algoan/nestjs-google-pubsub-microservice": "file:packages/google-pubsub-microservice",
     "@algoan/nestjs-http-exception-filter": "file:packages/http-exception-filter",
     "@algoan/nestjs-logging-interceptor": "file:packages/logging-interceptor",
-    "@algoan/nestjs-pagination": "file:packages/pagination",
-    "@algoan/nestjs-class-validators": "file:packages/class-validators"
+    "@algoan/nestjs-pagination": "file:packages/pagination"
   }
 }

--- a/packages/class-transformers/README.md
+++ b/packages/class-transformers/README.md
@@ -1,0 +1,30 @@
+# Nestjs class transformers
+
+Extends [class-transformers package](https://github.com/typestack/class-transformer) with additional features.
+
+## Installation
+
+```bash
+npm install --save @algoan/nestjs-class-transformers
+```
+
+## EnumFallback
+
+### Usage
+
+```ts
+import { EnumFallback } from '@algoan/nestjs-class-transformers';
+
+export enum UserRole {
+  ADMIN = 'ADMIN',
+  READER = 'READER',
+}
+
+class User {
+  @EnumFallback({
+    type: UserRole,
+    fallback: (value: UserRole) => UserRole.READER // if the role is not "ADMIN" or "READER", then the role will be "READER".
+  })
+  public role?: UserRole;
+}
+```

--- a/packages/class-transformers/README.md
+++ b/packages/class-transformers/README.md
@@ -28,3 +28,21 @@ class User {
   public role?: UserRole;
 }
 ```
+
+It works with array too:
+```ts
+import { EnumFallback } from '@algoan/nestjs-class-transformers';
+
+export enum UserRole {
+  ADMIN = 'ADMIN',
+  READER = 'READER',
+}
+
+class User {
+  @EnumFallback({
+    type: UserRole,
+    fallback: (value: UserRole) => UserRole.READER // if an array element is not "ADMIN" or "READER", then the role will be "READER".
+  })
+  public roles: UserRole[];
+}
+```

--- a/packages/class-transformers/jest.config.js
+++ b/packages/class-transformers/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    ...require('../jest.common'),
+
+    coverageDirectory: "coverage",
+    collectCoverageFrom: ["./src/**/*.ts"],
+
+    rootDir: ".",
+};

--- a/packages/class-transformers/package.json
+++ b/packages/class-transformers/package.json
@@ -1,15 +1,37 @@
 {
   "name": "@algoan/nestjs-class-transformers",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "description": "Class transformers for NestJS",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p .",
     "test:cov": "jest --coverage",
     "test": "jest"
   },
-  "author": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/algoan/nestjs-components.git",
+    "directory": "packages/class-transformers"
+  },
+  "files": [
+    "dist/src"
+  ],
+  "keywords": [
+    "nodejs",
+    "typescript",
+    "nestjs",
+    "class-transformers"
+  ],
+  "author": "Algoan",
   "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/algoan/nestjs-components.git"
+  },
+  "homepage": "https://github.com/algoan/nestjs-components/packages/nestjs-class-transformers",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "class-transformer": "^0.5.1"
   }

--- a/packages/class-transformers/package.json
+++ b/packages/class-transformers/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@algoan/nestjs-class-transformers",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc -p .",
+    "test:cov": "jest --coverage",
+    "test": "jest"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "class-transformer": "^0.5.1"
+  }
+}

--- a/packages/class-transformers/src/enum-fallback.decorator.ts
+++ b/packages/class-transformers/src/enum-fallback.decorator.ts
@@ -1,0 +1,40 @@
+import { Transform, TransformOptions } from 'class-transformer';
+
+/**
+ * Options for EnumFallback decorator.
+ */
+export interface EnumFallbackOptions<T> {
+  /**
+   * The enum type to check against.
+   */
+  type: { [s: string]: T };
+  /**
+   * A function that returns the fallback value.
+   * @param value The invalid value.
+   */
+  fallback: (value: T) => T;
+}
+
+/**
+ * Return given literal value if it is included in the specific enum type.
+ * Otherwise, return the value provided by the given fallback function.
+ */
+export const EnumFallback = <T>(
+  params: EnumFallbackOptions<T>,
+  transformOptions?: TransformOptions,
+): PropertyDecorator => {
+  const { type, fallback } = params;
+
+  return Transform(({ value }) => {
+    // eslint-disable-next-line no-null/no-null
+    if (value === undefined || value === null) {
+      return value;
+    }
+
+    if (!Object.values(type).includes(value)) {
+      return fallback(value);
+    }
+
+    return value;
+  }, transformOptions);
+};

--- a/packages/class-transformers/src/index.ts
+++ b/packages/class-transformers/src/index.ts
@@ -1,0 +1,1 @@
+export * from './enum-fallback.decorator';

--- a/packages/class-transformers/src/index.ts
+++ b/packages/class-transformers/src/index.ts
@@ -1,1 +1,2 @@
 export * from './enum-fallback.decorator';
+export * from 'class-transformer';

--- a/packages/class-transformers/test/enum-fallback-decorator.test.ts
+++ b/packages/class-transformers/test/enum-fallback-decorator.test.ts
@@ -1,0 +1,66 @@
+/* eslint-disable no-null/no-null */
+/* eslint-disable max-classes-per-file */
+import { plainToInstance } from 'class-transformer';
+import { EnumFallback } from '../src';
+
+describe('EnumFallback Decorator', () => {
+  enum UserRole {
+    ADMIN = 'ADMIN',
+    READER = 'READER',
+  }
+
+  it('should return the given value if it is valid', async () => {
+    class User {
+      @EnumFallback({ type: UserRole, fallback: () => UserRole.READER })
+      public role?: UserRole;
+    }
+
+    const user = plainToInstance(User, { role: 'ADMIN' });
+
+    expect(user.role).toEqual(UserRole.ADMIN);
+  });
+
+  it('should return the fallback value if the given value is invalid', async () => {
+    class User {
+      @EnumFallback({ type: UserRole, fallback: () => UserRole.READER })
+      public role?: UserRole;
+    }
+
+    const user = plainToInstance(User, { role: 'WRITER' });
+
+    expect(user.role).toEqual(UserRole.READER);
+  });
+
+  it('should return undefined if the given value is undefined', async () => {
+    class User {
+      @EnumFallback({ type: UserRole, fallback: () => UserRole.READER })
+      public role?: UserRole;
+    }
+
+    const user = plainToInstance(User, { role: undefined });
+
+    expect(user.role).toBeUndefined();
+  });
+
+  it('should return undefined if the given value is null', async () => {
+    class User {
+      @EnumFallback({ type: UserRole, fallback: () => UserRole.READER })
+      public role?: UserRole;
+    }
+
+    const user = plainToInstance(User, { role: null });
+
+    expect(user.role).toBe(null);
+  });
+
+  it('should take into account the transform options', async () => {
+    class User {
+      @EnumFallback({ type: UserRole, fallback: () => UserRole.READER }, { groups: ['group1'] })
+      public role?: UserRole;
+    }
+
+    const user = plainToInstance(User, { role: 'WRITER' }, { groups: ['group2'] });
+
+    expect(user.role).toEqual('WRITER');
+  });
+});

--- a/packages/class-transformers/test/enum-fallback-decorator.test.ts
+++ b/packages/class-transformers/test/enum-fallback-decorator.test.ts
@@ -63,4 +63,15 @@ describe('EnumFallback Decorator', () => {
 
     expect(user.role).toEqual('WRITER');
   });
+
+  it('should return the fallback value for each invalid element if the property is an array', async () => {
+    class User {
+      @EnumFallback({ type: UserRole, fallback: () => UserRole.READER })
+      public roles?: UserRole[];
+    }
+
+    const user = plainToInstance(User, { roles: ['WRITER', 'ADMIN'] });
+
+    expect(user.roles).toEqual([UserRole.READER, UserRole.ADMIN]);
+  });
 });

--- a/packages/class-transformers/test/enum-fallback-decorator.test.ts
+++ b/packages/class-transformers/test/enum-fallback-decorator.test.ts
@@ -74,4 +74,28 @@ describe('EnumFallback Decorator', () => {
 
     expect(user.roles).toEqual([UserRole.READER, UserRole.ADMIN]);
   });
+
+  it('should allow to run side effects in fallback function if the given value is invalid', async () => {
+    const log = jest.fn();
+    // eslint-disable-next-line no-console
+    console.log = log;
+
+    class User {
+      @EnumFallback({
+        type: UserRole,
+        fallback: () => {
+          // eslint-disable-next-line no-console
+          console.log('fallback function called');
+
+          return UserRole.READER;
+        },
+      })
+      public role?: UserRole;
+    }
+
+    const user = plainToInstance(User, { role: 'WRITER' });
+
+    expect(user.role).toEqual(UserRole.READER);
+    expect(log).toHaveBeenCalledWith('fallback function called');
+  });
 });

--- a/packages/class-transformers/tsconfig.json
+++ b/packages/class-transformers/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "extends": "../tsconfig.base.json",
+    "compilerOptions": {
+      "declaration": true,
+      "experimentalDecorators": true,
+      "outDir": "dist",
+    },
+    "include": [
+      "./src/**/*",
+      "./test/**/*.ts"
+    ],
+    "exclude": [
+      "node_modules"
+    ]
+  }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Create class-transformers package with new decorator `EnumFallback`. This decorator can be used as follows:
```ts
import { EnumFallback } from '@algoan/nestjs-class-transformers';

export enum UserRole {
  ADMIN = 'ADMIN',
  READER = 'READER',
}

class User {
  @EnumFallback({
    type: UserRole,
    fallback: (value: UserRole) => UserRole.READER // if the role is not "ADMIN" or "READER", then the role will be "READER".
  })
  public role?: UserRole;
}
```

Finishes implementation started in #836

<!--- Describe your changes in detail -->

## Motivation and Context
Fix #834 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
