### PR TITLE
[FEAT] Add getter functions for logging interceptor fields

### DIFF
--- a/packages/logging-interceptor/src/logging.interceptor.ts
+++ b/packages/logging-interceptor/src/logging.interceptor.ts
@@ -77,11 +77,25 @@ export class LoggingInterceptor implements NestInterceptor {
   }
 
   /**
+   * Return the user prefix
+   */
+  public getUserPrefix(): string {
+    return this.userPrefix;
+  }
+
+  /**
    * User prefix setter
    * ex. [MyPrefix - LoggingInterceptor - 200 - GET - /]
    */
   public setUserPrefix(prefix: string): void {
     this.userPrefix = `${prefix} - `;
+  }
+
+  /**
+   * Return the disable masking flag
+   */
+  public getDisabledMasking(): boolean {
+    return this.disableMasking;
   }
 
   /**
@@ -93,11 +107,25 @@ export class LoggingInterceptor implements NestInterceptor {
   }
 
   /**
+   * Return the masking placeholder
+   */
+  public getMaskingPlaceholder(): string | undefined {
+    return this.maskingPlaceholder;
+  }
+
+  /**
    * Set the masking placeholder
    * @param placeholder
    */
   public setMaskingPlaceholder(placeholder: string | undefined): void {
     this.maskingPlaceholder = placeholder;
+  }
+
+  /**
+   * Return the masking options
+   */
+  public getMask(): LoggingInterceptorMaskingOptions | undefined {
+    return this.mask;
   }
 
   /**

--- a/packages/logging-interceptor/test/logging.interceptor.test.ts
+++ b/packages/logging-interceptor/test/logging.interceptor.test.ts
@@ -399,6 +399,39 @@ describe('Logging interceptor', () => {
     });
   });
 
+  describe('LoggingInterceptor - Getters and setters', () => {
+    it('allows to set and get a user prefix', async () => {
+      const interceptor = new LoggingInterceptor();
+      const prefix = 'MyPrefix';
+      interceptor.setUserPrefix(prefix);
+      expect(interceptor.getUserPrefix()).toEqual(`${prefix} - `);
+    });
+
+    it('allows to set and get the disable masking flag', async () => {
+      const interceptor = new LoggingInterceptor();
+      interceptor.setDisableMasking(true);
+      expect(interceptor.getDisabledMasking()).toEqual(true);
+    });
+
+    it('allows to set and get the masking placeholder', async () => {
+      const interceptor = new LoggingInterceptor();
+      const placeholder = '****';
+      interceptor.setMaskingPlaceholder(placeholder);
+      expect(interceptor.getMaskingPlaceholder()).toEqual(placeholder);
+    });
+
+    it('allows to set and get the masking options', async () => {
+      const interceptor = new LoggingInterceptor();
+      const mask = {
+        requestHeader: {
+          authorization: true,
+        },
+      };
+      interceptor.setMask(mask);
+      expect(interceptor.getMask()).toEqual(mask);
+    });
+  });
+
   describe('LoggingInterceptor - Masking options', () => {
     const placeholder = '****';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add the following public methods to `LoggingInterceptor` class:
- `getUserPrefix`
- `getDisabledMasking`
- `getMaskingPlaceholder`
- `getMask`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Setter methods are already provided for the related fields and usually, getters should be also provided by the class. For instance, it can be useful to retrieve the masking placeholder to apply it for masking other sensitive data, not handled by this interceptor.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
