### PR TITLE
fix(deps): restrict @algoan/pubsub peer dependency

### DIFF
--- a/packages/google-pubsub-client/package.json
+++ b/packages/google-pubsub-client/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/algoan/nestjs-components/issues"
   },
   "peerDependencies": {
-    "@algoan/pubsub": ">=4",
+    "@algoan/pubsub": ">=4 < 7",
     "@nestjs/common": ">=8",
     "@nestjs/core": ">=8",
     "@nestjs/microservices": ">=8",

--- a/packages/google-pubsub-microservice/package.json
+++ b/packages/google-pubsub-microservice/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/algoan/nestjs-components/issues"
   },
   "peerDependencies": {
-    "@algoan/pubsub": ">=4",
+    "@algoan/pubsub": ">=4 < 7",
     "@nestjs/common": ">=8",
     "@nestjs/core": ">=8",
     "@nestjs/microservices": ">=8"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Avoid installing the future v7 of @algoan/pubsub

## Motivation and Context

With the future alpha release of [@algoan/pubsub](https://github.com/algoan/pubsub/pull/615), I wanted to make sure that it could not be installed 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
