### PR TITLE
[http-exception-filter] Add raw error message to logs

### DIFF
--- a/packages/http-exception-filter/src/http-exception-filter.ts
+++ b/packages/http-exception-filter/src/http-exception-filter.ts
@@ -104,6 +104,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
       this.logger.error(
         {
           message: `${status} [${request.method} ${request.url}] has thrown a critical error`,
+          rawErrorMessage: message,
           headers: this.maskHeaders(request.headers),
         },
         exceptionStack,
@@ -111,6 +112,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
     } else if (status >= HttpStatus.BAD_REQUEST) {
       this.logger.warn({
         message: `${status} [${request.method} ${request.url}] has thrown an HTTP client error`,
+        rawErrorMessage: message,
         exceptionStack,
         headers: this.maskHeaders(request.headers),
       });

--- a/packages/http-exception-filter/test/http-exception-filter.test.ts
+++ b/packages/http-exception-filter/test/http-exception-filter.test.ts
@@ -46,6 +46,7 @@ describe('Http Exception Filter', () => {
 
     expect(warnSpy).toHaveBeenCalledWith({
       message: `400 [GET ${url}] has thrown an HTTP client error`,
+      rawErrorMessage: 'The request is malformed.',
       exceptionStack: expect.any(String),
       headers: expect.anything(),
     });
@@ -65,6 +66,7 @@ describe('Http Exception Filter', () => {
 
     expect(warnSpy).toHaveBeenCalledWith({
       message: `400 [POST ${url}] has thrown an HTTP client error`,
+      rawErrorMessage: 'name should not be empty',
       exceptionStack: expect.any(String),
       headers: expect.anything(),
     });
@@ -85,6 +87,7 @@ describe('Http Exception Filter', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       {
         message: `500 [GET ${url}] has thrown a critical error`,
+        rawErrorMessage: 'A critical error happened.',
         headers: expect.anything(),
       },
       expect.any(String),
@@ -106,6 +109,7 @@ describe('Http Exception Filter', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       {
         message: `500 [GET ${url}] has thrown a critical error`,
+        rawErrorMessage: 'An internal server error occurred',
         headers: expect.anything(),
       },
       expect.any(String),
@@ -126,6 +130,7 @@ describe('Http Exception Filter', () => {
 
     expect(warnSpy).toHaveBeenCalledWith({
       message: `404 [GET ${url}] has thrown an HTTP client error`,
+      rawErrorMessage: 'Id notfound could not be found',
       exceptionStack: expect.any(String),
       headers: expect.anything(),
     });
@@ -153,6 +158,10 @@ describe('Http Exception Filter', () => {
 
     expect(warnSpy).toHaveBeenCalledWith({
       message: `413 [POST ${url}] has thrown an HTTP client error`,
+      rawErrorMessage: `
+        Your request entity size is too big for the server to process it:
+          - request size: 590001;
+          - request limit: 102400.`,
       exceptionStack: expect.any(String),
       headers: expect.anything(),
     });
@@ -185,6 +194,7 @@ describe('Http Exception Filter', () => {
 
     expect(warnSpy).toHaveBeenCalledWith({
       message: `404 [GET ${url}] has thrown an HTTP client error`,
+      rawErrorMessage: 'Id notfound could not be found',
       exceptionStack: expect.any(String),
       headers: expect.objectContaining({
         authorization: 'Bearer',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Add raw error message to logs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If the HTTP error message is not logged somewhere else (e.g. with the package logging-interceptor), the error may never be logged and thus hard to debug.

This PR adds the error message returned to the client for easier debugging.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
